### PR TITLE
Improve setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,27 @@
 
 This repository contains a sample FastAPI backend and agent for deploying user uploaded Gradio or Docker apps on a GPU server.
 
+## Prerequisites
+
+- Python 3 with the following packages:
+  - `fastapi`
+  - `uvicorn`
+  - `requests`
+- Docker installed and running
+
 ## Backend
 
 Run the backend server:
 
 ```bash
+uvicorn backend.main:app --reload
+```
+
+Example setup:
+
+```bash
+pip install fastapi uvicorn requests
+export AGENT_URL=http://localhost:8001  # adjust if agent runs elsewhere
 uvicorn backend.main:app --reload
 ```
 
@@ -25,3 +41,18 @@ uvicorn agent.agent:app --port 8001
 ```
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
+
+Example setup:
+
+```bash
+pip install fastapi uvicorn requests
+export BACKEND_URL=http://localhost:8000  # adjust if backend runs elsewhere
+uvicorn agent.agent:app --port 8001
+```
+
+### Environment Variables
+
+- `AGENT_URL`: URL where the agent can be reached (used by the backend).
+  Defaults to `http://localhost:8001`.
+- `BACKEND_URL`: URL of the backend API (used by the agent).
+  Defaults to `http://localhost:8000`.


### PR DESCRIPTION
## Summary
- add prerequisites section
- document AGENT_URL and BACKEND_URL environment variables
- give example setup commands for backend and agent

## Testing
- `python -m py_compile backend/main.py agent/agent.py`