### PR TITLE
Add standard Python .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+dist/
+.eggs/
+*.egg-info/
+
+# Virtual environments
+env/
+venv/
+ENV/
+.venv/
+
+# Testing
+.pytest_cache/
+
+# Logs and databases
+*.db
+logs/
+uploads/
+
+# Misc
+*.log
+.DS_Store


### PR DESCRIPTION
## Summary
- create `.gitignore` to exclude Python build and runtime artifacts
- ignore uploads, logs, database files and virtual environments

## Testing
- `pytest -q` *(fails: command not found)*