### PR TITLE
Serve frontend from FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ uvicorn backend.main:app --reload
    - **Docker**: include a `Dockerfile` in the uploaded directory or archive. If a `Dockerfile` is present the backend treats the app as a Docker project and builds it with `docker build`.
 
 2. **Send a request**
-   - Via the frontend: open `frontend/index.html` in a browser and select a file to upload.
+  - Via the frontend: open `http://localhost:8000` in a browser and select a file to upload.
    - Via `curl`:
 
      ```bash
@@ -84,10 +84,4 @@ uvicorn agent.agent:app --port 8001
   Defaults to `http://localhost:8000`.
 ## Frontend
 
-A minimal React+Tailwind UI is available in `frontend/index.html`. It can be served using any static file server. For example:
-
-```bash
-python -m http.server 3000 --directory frontend
-```
-
-Then open `http://localhost:3000` in your browser.
+A minimal React+Tailwind UI is included in `frontend/index.html`. The backend now serves this file automatically, so simply navigate to `http://localhost:8000` in your browser after starting the backend.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 """FastAPI backend for MLOps app deployment."""
 from fastapi import FastAPI, UploadFile, File, HTTPException
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 import shutil
 import os
@@ -15,6 +16,14 @@ UPLOAD_DIR = "./uploads"
 LOG_DIR = "./logs"
 AGENT_URL = os.environ.get("AGENT_URL", "http://localhost:8001")
 app = FastAPI()
+
+# Serve the React frontend from the same origin
+app.mount("/static", StaticFiles(directory="frontend"), name="frontend")
+
+@app.get("/", include_in_schema=False)
+async def frontend_index():
+    """Return the frontend single-page app."""
+    return FileResponse("frontend/index.html")
 
 # Allowed pattern for uploaded filenames
 ALLOWED_FILENAME = re.compile(r"^[A-Za-z0-9._-]+$")


### PR DESCRIPTION
## Summary
- mount the `frontend` directory in the FastAPI app
- serve `index.html` on `/`
- update README with unified frontend instructions

## Testing
- `pytest -q` *(fails: command not found)*