### PR TITLE
Add URL/port fields and display links

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,8 +28,7 @@
         fetch('/status')
           .then(res => res.json())
           .then(data => {
-            const list = Object.entries(data).map(([id, status]) => ({ id, status }));
-            setApps(list);
+            setApps(data);
           })
           .catch(() => {});
       }, []);
@@ -38,8 +37,7 @@
         fetch('/status')
           .then(res => res.json())
           .then(data => {
-            const list = Object.entries(data).map(([id, status]) => ({ id, status }));
-            setApps(list);
+            setApps(data);
           });
       };
 
@@ -110,6 +108,9 @@
                   <div>
                     <h2 className="font-semibold">{app.id}</h2>
                     <p className="text-sm text-gray-600">Status: {app.status}</p>
+                    {app.url && (
+                      <a href={app.url} target="_blank" rel="noopener" className="text-blue-600 text-sm underline">Open</a>
+                    )}
                   </div>
                   <div>
                     <button onClick={() => toggleLogs(app.id)} className="bg-gray-200 px-3 py-1 rounded text-sm hover:bg-gray-300">{showLogs[app.id] ? 'Hide Logs' : 'View Logs'}</button>


### PR DESCRIPTION
## Summary
- extend DB schema to store port and app url
- allocate a free port on upload and store url with app record
- expose url in status API and upload response
- update frontend to consume new API response and show "Open" link for each app

## Testing
- `python3 -m py_compile backend/main.py agent/agent.py`
- `pytest -q` *(fails: command not found)*