### PR TITLE
Add port handling and stop endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ uvicorn backend.main:app --reload
 - `GET /status`: check running status of apps.
 - `GET /logs/{app_id}`: view logs for an app.
 - `POST /update_status`: (used by agent) update status in the database.
+- `POST /stop`: stop a running app.
 
 ### Uploading Gradio or Docker apps
 
@@ -67,6 +68,8 @@ uvicorn agent.agent:app --port 8001
 ```
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
+
+The backend specifies a port for each app which the agent forwards to Docker or sets as `GRADIO_SERVER_PORT` for Gradio scripts.
 
 Example setup:
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,11 +1,16 @@
 """Simple agent running on GPU server to build/run apps."""
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import subprocess
 import os
 import requests
+import threading
+import time
 
 BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000")
+
+# store running processes keyed by app_id
+processes = {}
 
 app = FastAPI()
 
@@ -14,19 +19,24 @@ class RunRequest(BaseModel):
     path: str
     type: str
     log_path: str
+    port: int
 
 
-def run_command(cmd, log_path, wait=True):
+class StopRequest(BaseModel):
+    app_id: str
+
+
+def run_command(cmd, log_path, wait=True, env=None):
     """Run a command and optionally wait for completion."""
     with open(log_path, "a") as log:
-        process = subprocess.Popen(cmd, stdout=log, stderr=log)
+        process = subprocess.Popen(cmd, stdout=log, stderr=log, env=env)
     if wait:
         process.wait()
         return process.returncode
-    return process.pid
+    return process
 
 @app.post("/run")
-async def run_app(req: RunRequest, background_tasks: BackgroundTasks):
+async def run_app(req: RunRequest):
     if req.type == "docker":
         build_cmd = ["docker", "build", "-t", req.app_id, req.path]
         ret = run_command(build_cmd, req.log_path)
@@ -36,8 +46,17 @@ async def run_app(req: RunRequest, background_tasks: BackgroundTasks):
                 json={"app_id": req.app_id, "status": "error"},
             )
             raise HTTPException(status_code=500, detail="build failed")
-        run_cmd = ["docker", "run", "--rm", "--name", req.app_id, req.app_id]
-        background_tasks.add_task(run_command, run_cmd, req.log_path, False)
+        run_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            req.app_id,
+            "-p",
+            f"{req.port}:{req.port}",
+            req.app_id,
+        ]
+        proc = run_command(run_cmd, req.log_path, False)
     else:  # gradio
         py_files = [f for f in os.listdir(req.path) if f.endswith(".py")]
         target = py_files[0] if py_files else None
@@ -48,9 +67,39 @@ async def run_app(req: RunRequest, background_tasks: BackgroundTasks):
             )
             raise HTTPException(status_code=400, detail="no python file")
         cmd = ["python", os.path.join(req.path, target)]
-        background_tasks.add_task(run_command, cmd, req.log_path, False)
-    # report running status
-    requests.post(f"{BACKEND_URL}/update_status", json={"app_id": req.app_id, "status": "running"})
+        env = os.environ.copy()
+        env["GRADIO_SERVER_PORT"] = str(req.port)
+        proc = run_command(cmd, req.log_path, False, env=env)
+    processes[req.app_id] = {"process": proc, "type": req.type, "log_path": req.log_path}
+
+    def monitor():
+        while True:
+            if proc.poll() is not None:
+                requests.post(
+                    f"{BACKEND_URL}/update_status",
+                    json={"app_id": req.app_id, "status": "stopped"},
+                )
+                processes.pop(req.app_id, None)
+                break
+            time.sleep(5)
+
+    threading.Thread(target=monitor, daemon=True).start()
+    requests.post(
+        f"{BACKEND_URL}/update_status",
+        json={"app_id": req.app_id, "status": "running"},
+    )
     return {"detail": "started"}
+
+
+@app.post("/stop")
+async def stop_app(req: StopRequest):
+    info = processes.get(req.app_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="app not running")
+    if info["type"] == "docker":
+        subprocess.run(["docker", "stop", req.app_id])
+    else:
+        info["process"].terminate()
+    return {"detail": "stopping"}
 
 # Example: run with `uvicorn agent.agent:app --port 8001`


### PR DESCRIPTION
## Summary
- handle per-app target ports
- monitor running apps and stop them via new endpoint
- document new API and port handling in README

## Testing
- `python -m py_compile agent/agent.py backend/main.py`