### PR TITLE
Fix FastAPI imports and remove duplicate class

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,5 +1,5 @@
 """Simple agent running on GPU server to build/run apps."""
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 import subprocess
 import os
@@ -31,9 +31,6 @@ class RunRequest(BaseModel):
     port: int
 
 
-
-class StopRequest(BaseModel):
-    app_id: str
 
 class StopRequest(BaseModel):
     app_id: str


### PR DESCRIPTION
## Summary
- update FastAPI import line
- remove duplicate `StopRequest` class

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*
- `uvicorn agent.agent:app --port 8001` *(fails: ModuleNotFoundError: No module named 'requests')*