### PR TITLE
Fix interpreter command for agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ uvicorn agent.agent:app --port 8001
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
 
-The backend specifies a port for each app which the agent forwards to Docker or sets as `GRADIO_SERVER_PORT` for Gradio scripts.
+The backend specifies a port for each app which the agent forwards to Docker or sets as `GRADIO_SERVER_PORT` for Gradio scripts. When running a Gradio project, the agent uses the same Python interpreter that launched the agent (`sys.executable`).
 
 Example setup:
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 import subprocess
 import os
+import sys
 import requests
 import asyncio
 from typing import List, Optional
@@ -74,7 +75,7 @@ async def run_app(req: RunRequest, background_tasks: BackgroundTasks):
                 json={"app_id": req.app_id, "status": "error"},
             )
             raise HTTPException(status_code=400, detail="no python file")
-        cmd = ["python", os.path.join(req.path, target)]
+        cmd = [sys.executable, os.path.join(req.path, target)]
         proc = run_command(cmd, req.log_path, False, env={"PORT": str(req.port)})
     PROCESSES[req.app_id] = proc
     background_tasks.add_task(heartbeat_loop, req.app_id)


### PR DESCRIPTION
## Summary
- use `sys.executable` when launching user python scripts so they run under the same interpreter as the agent
- document interpreter usage in README

## Testing
- `pytest -q`