### PR TITLE
Fix README env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ uvicorn agent.agent:app --port 8001
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
 
-The backend specifies a port for each app which the agent forwards to Docker or sets as `GRADIO_SERVER_PORT` for Gradio scripts.
+The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts.
 
 Example setup:
 


### PR DESCRIPTION
## Summary
- fix reference to GRADIO_SERVER_PORT in README

## Testing
- `pytest -q`