### PR TITLE
Clean up routes when app exits

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -101,6 +101,8 @@ async def heartbeat_loop(app_id: str):
                 )
             except Exception:
                 pass
+            # Clean up Nginx routing for this app
+            remove_route(app_id)
             PROCESSES.pop(app_id, None)
             break
         try:


### PR DESCRIPTION
## Summary
- remove nginx route in `heartbeat_loop` when the process exits

## Testing
- `python` script importing `agent` with stub modules and running `heartbeat_loop` to verify `proxy/routes.json` is empty after the process exits