### PR TITLE
Handle route removal on app delete

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -36,6 +36,9 @@ class RunRequest(BaseModel):
 class StopRequest(BaseModel):
     app_id: str
 
+class RemoveRouteRequest(BaseModel):
+    app_id: str
+
 def run_command(cmd, log_path, wait=True, env=None):
     """Run a command and optionally wait for completion."""
     env_vars = os.environ.copy()
@@ -150,6 +153,13 @@ async def stop_app(req: StopRequest):
         pass
 
     return {"detail": "stopped"}
+
+
+@app.post("/remove_route")
+async def remove_route_endpoint(req: RemoveRouteRequest):
+    """Remove an app's proxy route regardless of process state."""
+    remove_route(req.app_id)
+    return {"detail": "removed"}
 
 
 # Example: run with `uvicorn agent.agent:app --port 8001`

--- a/backend/main.py
+++ b/backend/main.py
@@ -320,7 +320,17 @@ async def delete_app(app_id: str):
 
     if status == "running":
         try:
-            requests.post(f"{AGENT_URL}/stop", json={"app_id": app_id}, timeout=5)
+            requests.post(
+                f"{AGENT_URL}/stop", json={"app_id": app_id}, timeout=5
+            )
+        except Exception:
+            pass
+    else:
+        # Ensure the proxy route is removed for non-running apps
+        try:
+            requests.post(
+                f"{AGENT_URL}/remove_route", json={"app_id": app_id}, timeout=5
+            )
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- remove routes for non-running apps when deleting
- expose `POST /remove_route` endpoint in agent

## Testing
- `python -m py_compile backend/main.py agent/agent.py`