### PR TITLE
Support IP allowlist and auth header in upload flow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -146,6 +146,7 @@ async def upload_app(
 ):
 
     """Receive user uploaded app and trigger agent build/run."""
+    allowed = [ip.strip() for ip in allow_ips.split(',')] if allow_ips else None
     # Reject duplicate app names
     conn = sqlite3.connect(DATABASE)
     c = conn.cursor()
@@ -205,6 +206,8 @@ async def upload_app(
                 "type": app_type,
                 "log_path": log_path,
                 "port": port,
+                "allow_ips": allowed,
+                "auth_header": auth_header,
             },
             timeout=5,
         )


### PR DESCRIPTION
## Summary
- parse `allow_ips` from upload form into a list
- include `allow_ips` and `auth_header` in the `/run` request sent to the agent
- verified proxy config includes allow and auth header rules

## Testing
- `python -m py_compile backend/main.py agent/agent.py proxy/proxy.py`
- `PROXY_LINK_PATH="/workspace/codex_test/proxy/apps.conf" python - <<'EOF'
from proxy.proxy import add_route
add_route('demo', 9001, ['10.0.0.1'], 'X-Token')
print(open('proxy/apps.conf').read())
EOF`