### PR TITLE
Add redirect for apps without trailing slash

### DIFF
--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -49,6 +49,9 @@ def save_routes(routes):
 def generate_config(routes):
     lines = ["server {", "    listen 80;"]
     for app_id, info in routes.items():
+        lines.append(f"    location = /apps/{app_id} {{")
+        lines.append(f"        return 301 /apps/{app_id}/;")
+        lines.append("    }")
         lines.append(f"    location /apps/{app_id}/ {{")
         lines.append(f"        proxy_pass http://127.0.0.1:{info['port']}/;")
         if info.get("allow_ips"):


### PR DESCRIPTION
## Summary
- update proxy config generation to redirect `/apps/<app>` to `/apps/<app>/`

## Testing
- `pytest -q`