### PR TITLE
Update startup to reuse port reservations

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -386,6 +386,19 @@ async def cleanup_task():
 
 @app.on_event("startup")
 async def startup_event():
+    # Remove ports for any apps that are already running
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute(
+        "SELECT port FROM apps WHERE status='running' AND port IS NOT NULL"
+    )
+    rows = c.fetchall()
+    conn.close()
+    for row in rows:
+        port = row[0]
+        if port in AVAILABLE_PORTS:
+            AVAILABLE_PORTS.remove(port)
+
     asyncio.create_task(cleanup_task())
 
 


### PR DESCRIPTION
## Summary
- remove ports of running apps from AVAILABLE_PORTS during startup

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_b_683fedb4ffec8320a1a73c1f04dd5a42