### PR TITLE
Update Docker run command and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ uvicorn agent.agent:app --port 8001
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
 
-The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts.
+The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this `PORT` environment variable.
 
 
 Example setup:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -96,7 +96,18 @@ async def build_and_run(req: RunRequest):
             finally:
                 remove_route(req.app_id)
             return
-        run_cmd = ["docker", "run", "--rm", "-p", f"{req.port}:{req.port}", "--name", req.app_id, req.app_id]
+        run_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-p",
+            f"{req.port}:{req.port}",
+            "-e",
+            f"PORT={req.port}",
+            "--name",
+            req.app_id,
+            req.app_id,
+        ]
         proc = await async_run_detached(run_cmd, req.log_path, env={"PORT": str(req.port)})
     else:  # gradio
         py_files = [f for f in os.listdir(req.path) if f.endswith(".py")]


### PR DESCRIPTION
## Summary
- pass `PORT` as env variable when running docker containers
- document PORT usage for Docker apps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683fff191e5c832082dce093b1cdfbdc