### PR TITLE
Check ports before app start

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ The agent builds and runs Docker or Gradio apps and reports status back to the b
 
 The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this `PORT` environment variable.
 
+During upload the backend now verifies that the chosen port is free by briefly
+binding to it. If the port is busy another from the `AVAILABLE_PORTS` pool is
+tried. The agent performs the same check before launching an app, failing the
+run if the port cannot be bound.
+
 
 Example setup:
 


### PR DESCRIPTION
## Summary
- ensure the backend verifies ports are available before allocation
- verify port availability in the agent too
- document port checking behavior in README

## Testing
- `python -m py_compile backend/main.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_b_6840107488b483209f6b1e03082d890b