### PR TITLE
Unify stopped status across backend and agent

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -234,7 +234,7 @@ async def stop_app(req: StopRequest):
         async with httpx.AsyncClient() as client:
             await client.post(
                 f"{BACKEND_URL}/update_status",
-                json={"app_id": req.app_id, "status": "finished"},
+                json={"app_id": req.app_id, "status": "stopped"},
                 timeout=5,
             )
     except Exception:

--- a/backend/main.py
+++ b/backend/main.py
@@ -279,7 +279,7 @@ async def upload_app(
 @app.post("/update_status")
 async def update_status(update: StatusUpdate):
     save_status(update.app_id, update.status)
-    if update.status in ("error", "finished"):
+    if update.status in ("error", "finished", "stopped"):
         release_app_port(update.app_id)
     return {"detail": "ok"}
 


### PR DESCRIPTION
## Summary
- ensure the backend releases ports on `stopped` updates
- notify backend with `stopped` status when an app is manually stopped

## Testing
- `python -m py_compile backend/main.py agent/agent.py`

------
https://chatgpt.com/codex/tasks/task_b_6841251b19a08320a5f2d39eafc485aa