### PR TITLE
Add polling after stopping apps

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,6 +44,21 @@
           });
       };
 
+      const pollStatus = (appId) => {
+        const interval = setInterval(() => {
+          fetch('/status')
+            .then(res => res.json())
+            .then(data => {
+              setApps(data);
+              const app = data.find(a => a.id === appId);
+              if (!app || app.status !== 'stopping') {
+                clearInterval(interval);
+              }
+            })
+            .catch(() => {});
+        }, 2000);
+      };
+
       const handleUpload = (e) => {
         e.preventDefault();
         if (files.length === 0) return;
@@ -92,7 +107,10 @@
 
       const stopApp = (id) => {
         fetch(`/stop/${id}`, { method: 'POST' })
-          .then(() => refreshStatus())
+          .then(() => {
+            refreshStatus();
+            pollStatus(id);
+          })
           .catch(() => {});
       };
 


### PR DESCRIPTION
## Summary
- poll the server every 2 seconds to update status
- automatically stop polling once app no longer reports `stopping`
- call this polling logic from `stopApp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684131d7f8f083209f51f9535e852af5