### PR TITLE
Fix gradio proxy root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ uvicorn backend.main:app --reload
 
 1. **Prepare your files**
    - **Gradio**: upload a single Python file or a zip archive containing your Gradio app. The backend will run the first `.py` file it finds in the uploaded directory.
+     You can use `examples/gradio_app.py` as a starting point; it reads the `ROOT_PATH` environment variable so the app works behind the proxy.
    - **Docker**: include a `Dockerfile` in the uploaded directory or archive. If a `Dockerfile` is present the backend treats the app as a Docker project and builds it with `docker build`.
 
 2. **Send a request**
@@ -73,7 +74,7 @@ uvicorn agent.agent:app --port 8001
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
 
-The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this `PORT` environment variable.
+The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this `PORT` environment variable. The agent additionally sets `ROOT_PATH` to `/apps/<app_id>` so frameworks like Gradio can launch under the correct path prefix by passing this value to their `root_path` argument.
 
 During upload the backend now verifies that the chosen port is free by briefly
 binding to it. If the port is busy another from the `AVAILABLE_PORTS` pool is

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -128,11 +128,17 @@ async def build_and_run(req: RunRequest):
             f"{req.port}:{req.port}",
             "-e",
             f"PORT={req.port}",
+            "-e",
+            f"ROOT_PATH=/apps/{req.app_id}",
             "--name",
             req.app_id,
             req.app_id,
         ]
-        proc = await async_run_detached(run_cmd, req.log_path, env={"PORT": str(req.port)})
+        proc = await async_run_detached(
+            run_cmd,
+            req.log_path,
+            env={"PORT": str(req.port), "ROOT_PATH": f"/apps/{req.app_id}"},
+        )
     else:  # gradio
         py_files = [f for f in os.listdir(req.path) if f.endswith(".py")]
         target = py_files[0] if py_files else None
@@ -148,7 +154,11 @@ async def build_and_run(req: RunRequest):
                 remove_route(req.app_id)
             return
         cmd = [sys.executable, os.path.join(req.path, target)]
-        proc = await async_run_detached(cmd, req.log_path, env={"PORT": str(req.port)})
+        proc = await async_run_detached(
+            cmd,
+            req.log_path,
+            env={"PORT": str(req.port), "ROOT_PATH": f"/apps/{req.app_id}"},
+        )
 
     # Store the process along with the type so that cleanup can behave
     # differently for docker vs gradio apps

--- a/examples/gradio_app.py
+++ b/examples/gradio_app.py
@@ -1,0 +1,14 @@
+import gradio as gr
+import os
+
+port = int(os.environ.get("PORT", 7860))
+root = os.environ.get("ROOT_PATH")
+
+
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+iface = gr.Interface(fn=greet, inputs="text", outputs="text")
+
+if __name__ == "__main__":
+    iface.launch(server_name="0.0.0.0", server_port=port, root_path=root)


### PR DESCRIPTION
## Summary
- support `ROOT_PATH` env var so apps run behind Nginx prefix
- document `ROOT_PATH` variable and example Gradio script
- add example `examples/gradio_app.py`

## Testing
- `python -m py_compile agent/agent.py examples/gradio_app.py backend/main.py proxy/proxy.py`

------
https://chatgpt.com/codex/tasks/task_b_68466bdb8dac8320ae6b2bc4802f8fc2