### PR TITLE
Fix proxy_pass without trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ return "Method Not Allowed." Each app is accessible via
 server {
     listen 8080;
     location /apps/<app_id>/ {
-        proxy_pass http://127.0.0.1:<port>/;
+        proxy_pass http://127.0.0.1:<port>;
     }
 }
 ```

--- a/proxy/nginx_template.conf
+++ b/proxy/nginx_template.conf
@@ -2,7 +2,7 @@ server {
     listen 8080;
     # example route
     location /apps/<app_id>/ {
-        proxy_pass http://127.0.0.1:<port>/;
+        proxy_pass http://127.0.0.1:<port>;
         # optional IP allowlist
         # allow 192.168.0.0/16;
         # deny all;

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -53,7 +53,7 @@ def generate_config(routes):
         lines.append(f"        return 301 /apps/{app_id}/;")
         lines.append("    }")
         lines.append(f"    location /apps/{app_id}/ {{")
-        lines.append(f"        proxy_pass http://127.0.0.1:{info['port']}/;")
+        lines.append(f"        proxy_pass http://127.0.0.1:{info['port']};")
         if info.get("allow_ips"):
             for ip in info["allow_ips"]:
                 lines.append(f"        allow {ip};")


### PR DESCRIPTION
## Summary
- generate `proxy_pass` lines without a trailing slash
- update nginx template accordingly
- fix README example to match the new proxy config

## Testing
- `python -m py_compile agent/agent.py examples/gradio_app.py backend/main.py proxy/proxy.py`

------
https://chatgpt.com/codex/tasks/task_b_68466f5385188320895b3634f9bebfb5