### PR TITLE
Add websocket headers to proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,18 @@ server {
     listen 8080;
     location /apps/<app_id>/ {
         proxy_pass http://127.0.0.1:<port>;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
     }
 }
 ```
 
-You can restrict access by providing `allow_ips` (comma separated IP list) or an
-`auth_header` when uploading an app. These values are injected into the Nginx
-location block.
+Gradio apps rely on WebSockets, so the proxy configuration must forward upgrade
+headers as shown above. You can restrict access by providing `allow_ips`
+(comma separated IP list) or an `auth_header` when uploading an app. These
+values are injected into the Nginx location block.
 ## Frontend
 
 A minimal React+Tailwind UI is included in `frontend/index.html`. The backend now serves this file automatically, so simply navigate to `http://localhost:8000` in your browser after starting the backend.

--- a/proxy/nginx_template.conf
+++ b/proxy/nginx_template.conf
@@ -3,6 +3,10 @@ server {
     # example route
     location /apps/<app_id>/ {
         proxy_pass http://127.0.0.1:<port>;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
         # optional IP allowlist
         # allow 192.168.0.0/16;
         # deny all;

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -54,6 +54,10 @@ def generate_config(routes):
         lines.append("    }")
         lines.append(f"    location /apps/{app_id}/ {{")
         lines.append(f"        proxy_pass http://127.0.0.1:{info['port']};")
+        lines.append("        proxy_http_version 1.1;")
+        lines.append("        proxy_set_header Upgrade $http_upgrade;")
+        lines.append('        proxy_set_header Connection "upgrade";')
+        lines.append("        proxy_set_header Host $host;")
         if info.get("allow_ips"):
             for ip in info["allow_ips"]:
                 lines.append(f"        allow {ip};")


### PR DESCRIPTION
## Summary
- support websockets in nginx template
- include websocket headers when generating config
- update README about websocket requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68467b47c1148320a8f794b94b16eb24