### PR TITLE
Update README and example for rewritten proxy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uvicorn backend.main:app --reload
 
 1. **Prepare your files**
    - **Gradio**: upload a single Python file or a zip archive containing your Gradio app. The backend will run the first `.py` file it finds in the uploaded directory.
-     You can use `examples/gradio_app.py` as a starting point; it reads the `ROOT_PATH` environment variable so the app works behind the proxy.
+    You can use `examples/gradio_app.py` as a starting point; it simply launches on the provided port. The proxy rewrites the path prefix so no extra `root_path` argument is needed.
    - **Docker**: include a `Dockerfile` in the uploaded directory or archive. If a `Dockerfile` is present the backend treats the app as a Docker project and builds it with `docker build`.
 
 2. **Send a request**
@@ -74,7 +74,7 @@ uvicorn agent.agent:app --port 8001
 
 The agent builds and runs Docker or Gradio apps and reports status back to the backend.
 
-The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this `PORT` environment variable. The agent additionally sets `ROOT_PATH` to `/apps/<app_id>` so frameworks like Gradio can launch under the correct path prefix by passing this value to their `root_path` argument.
+The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this variable. The proxy now rewrites incoming requests so frameworks like Gradio no longer need a `root_path` argument. The agent still sets `ROOT_PATH` for compatibility, but it can be ignored.
 
 During upload the backend now verifies that the chosen port is free by briefly
 binding to it. If the port is busy another from the `AVAILABLE_PORTS` pool is
@@ -116,7 +116,7 @@ return "Method Not Allowed." Each app is accessible via
 server {
     listen 8080;
     location /apps/<app_id>/ {
-        proxy_pass http://127.0.0.1:<port>;
+        proxy_pass http://127.0.0.1:<port>/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/examples/gradio_app.py
+++ b/examples/gradio_app.py
@@ -2,7 +2,6 @@ import gradio as gr
 import os
 
 port = int(os.environ.get("PORT", 7860))
-root = os.environ.get("ROOT_PATH")
 
 
 def greet(name: str) -> str:
@@ -11,4 +10,4 @@ def greet(name: str) -> str:
 iface = gr.Interface(fn=greet, inputs="text", outputs="text")
 
 if __name__ == "__main__":
-    iface.launch(server_name="0.0.0.0", server_port=port, root_path=root)
+    iface.launch(server_name="0.0.0.0", server_port=port)


### PR DESCRIPTION
## Summary
- clarify Gradio upload steps that no longer require `ROOT_PATH`
- explain new proxy behavior in agent section
- adjust proxy example to include trailing slash
- simplify example `gradio_app.py`

## Testing
- `python -m py_compile agent/agent.py backend/main.py examples/gradio_app.py proxy/proxy.py`


------
https://chatgpt.com/codex/tasks/task_b_68468bacfb4483209e0c13bf961566fa