### PR TITLE
Implement Docker container restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ uvicorn backend.main:app --reload
 - `GET /logs/{app_id}`: view logs for an app.
 - `POST /update_status`: (used by agent) update status in the database.
 - `POST /stop/{app_id}`: stop a running app.
+- `POST /restart/{app_id}`: restart a previously uploaded Docker app using the existing image.
 - `DELETE /apps/{app_id}`: remove an app and all associated files.
 
 ### Uploading Gradio or Docker apps


### PR DESCRIPTION
## Summary
- add `reuse_image` to agent run request
- support `/restart` endpoint in the agent that reuses the loaded image
- expand backend database to store `allow_ips` and `auth_header`
- record these fields on upload and reuse them for restart
- expose a new `/restart/{app_id}` endpoint in the backend
- document restart API in README

## Testing
- `python -m py_compile backend/main.py agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_b_6858e988aeb48320bb9fa9e9081560a8