### PR TITLE
Fix build phase cleanup

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -90,6 +90,15 @@ async def async_run_detached(cmd, log_path, env=None):
 async def run_app(req: RunRequest, background_tasks: BackgroundTasks):
     # configure the proxy for the assigned port and start build/run in background
     add_route(req.app_id, req.port, req.allow_ips, req.auth_header)
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{BACKEND_URL}/update_status",
+                json={"app_id": req.app_id, "status": "building"},
+                timeout=5,
+            )
+    except Exception:
+        pass
     background_tasks.add_task(build_and_run, req)
     return {"detail": "building"}
 
@@ -99,6 +108,15 @@ async def restart_app(req: RunRequest, background_tasks: BackgroundTasks):
     """Restart an app using an existing Docker image."""
     req.reuse_image = True
     add_route(req.app_id, req.port, req.allow_ips, req.auth_header)
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{BACKEND_URL}/update_status",
+                json={"app_id": req.app_id, "status": "building"},
+                timeout=5,
+            )
+    except Exception:
+        pass
     background_tasks.add_task(build_and_run, req)
     return {"detail": "restarting"}
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -281,7 +281,7 @@ async def upload_app(
             resp.raise_for_status()
         save_status(
             app_id,
-            "running",
+            "building",
             log_path,
             app_type=app_type,
             allow_ips=allowed_str,
@@ -327,7 +327,7 @@ async def upload_app(
         )
         raise HTTPException(status_code=500, detail=str(e))
 
-    return {"app_id": app_id, "status": "running", "url": url}
+    return {"app_id": app_id, "status": "building", "url": url}
 
 @app.post("/update_status")
 async def update_status(update: StatusUpdate):
@@ -478,7 +478,7 @@ async def restart_app(app_id: str):
             resp.raise_for_status()
         save_status(
             app_id,
-            "running",
+            "building",
             log_path,
             port=port,
             app_type=app_type,
@@ -497,7 +497,7 @@ async def restart_app(app_id: str):
         )
         raise HTTPException(status_code=500, detail=str(e))
 
-    return {"detail": "restarted", "url": f"/apps/{app_id}/"}
+    return {"detail": "restarting", "url": f"/apps/{app_id}/"}
 
 
 @app.delete("/apps/{app_id}")


### PR DESCRIPTION
## Summary
- keep apps in `building` state until the agent starts them
- send `building` status from the agent when `/run` or `/restart` is called

## Testing
- `python -m py_compile agent/agent.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_b_685a4dd91110832093ef7598b4af976f