### PR TITLE
Add template upload and one-click deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,16 @@ values are injected into the Nginx location block.
 ## Frontend
 
 A minimal React+Tailwind UI is included in `frontend/index.html`. The backend now serves this file automatically, so simply navigate to `http://localhost:8000` in your browser after starting the backend.
+
+## Templates
+
+You can store reusable app templates and deploy them with a single click.
+
+- `POST /templates` – upload a template archive or folder.
+  - `name`: template name.
+  - `file`: archive or single file containing the template.
+  - `description` (optional): short text shown in the UI.
+- `GET /templates` – list available templates.
+- `POST /deploy_template/{template_id}` – copy the template to the uploads directory and start it just like an uploaded app. The response includes the new `app_id` and URL.
+
+On the frontend the templates are loaded on page load and displayed with a **Deploy** button. Clicking it triggers the deployment endpoint and the running apps list is refreshed automatically.

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ import socket
 DATABASE = "./app.db"
 UPLOAD_DIR = "./uploads"
 LOG_DIR = "./logs"
+TEMPLATE_DIR = "./templates"
 AGENT_URL = os.environ.get("AGENT_URL", "http://localhost:8001")
 
 # Port range to allocate for running apps
@@ -55,6 +56,17 @@ def init_db():
         )
         """
     )
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS templates (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            type TEXT,
+            path TEXT,
+            description TEXT
+        )
+        """
+    )
     # Add new columns if database existed before
     c.execute("PRAGMA table_info(apps)")
     cols = [row[1] for row in c.fetchall()]
@@ -72,6 +84,7 @@ def init_db():
     conn.close()
     os.makedirs(UPLOAD_DIR, exist_ok=True)
     os.makedirs(LOG_DIR, exist_ok=True)
+    os.makedirs(TEMPLATE_DIR, exist_ok=True)
 
 init_db()
 
@@ -328,6 +341,148 @@ async def upload_app(
         raise HTTPException(status_code=500, detail=str(e))
 
     return {"app_id": app_id, "status": "building", "url": url}
+
+
+@app.post("/templates")
+async def upload_template(
+    name: str = Form(...),
+    file: UploadFile = File(...),
+    description: str = Form("")
+):
+    """Upload a template archive or file."""
+    template_id = str(uuid.uuid4())
+    t_dir = os.path.join(TEMPLATE_DIR, template_id)
+    os.makedirs(t_dir, exist_ok=True)
+    filename = os.path.basename(file.filename)
+    if not ALLOWED_FILENAME.fullmatch(filename):
+        raise HTTPException(status_code=400, detail="invalid filename")
+    file_location = os.path.join(t_dir, filename)
+    with open(file_location, "wb") as f:
+        shutil.copyfileobj(file.file, f)
+
+    if zipfile.is_zipfile(file_location):
+        with zipfile.ZipFile(file_location, "r") as z:
+            for member in z.namelist():
+                if os.path.isabs(member) or ".." in member.split("/"):
+                    raise HTTPException(status_code=400, detail="invalid zip entry path")
+                resolved = os.path.realpath(os.path.join(t_dir, member))
+                if not resolved.startswith(os.path.realpath(t_dir) + os.sep):
+                    raise HTTPException(status_code=400, detail="zip entry outside template directory")
+            z.extractall(t_dir)
+
+    if filename.lower().endswith(".tar"):
+        app_type = "docker_tar"
+        stored_path = filename
+    else:
+        app_type = "gradio"
+        stored_path = "."
+        for root, _, files in os.walk(t_dir):
+            for fname in files:
+                if fname.lower() == "dockerfile":
+                    app_type = "docker"
+                    break
+            if app_type == "docker":
+                break
+
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO templates(id, name, type, path, description) VALUES(?,?,?,?,?)",
+        (template_id, name.strip(), app_type, stored_path, description.strip()),
+    )
+    conn.commit()
+    conn.close()
+
+    return {"template_id": template_id}
+
+
+@app.get("/templates")
+async def list_templates():
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute("SELECT id, name, description FROM templates")
+    rows = c.fetchall()
+    conn.close()
+    return [
+        {"id": row[0], "name": row[1], "description": row[2] or ""}
+        for row in rows
+    ]
+
+
+@app.post("/deploy_template/{template_id}")
+async def deploy_template(template_id: str):
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute(
+        "SELECT name, type, path FROM templates WHERE id=?",
+        (template_id,),
+    )
+    row = c.fetchone()
+    conn.close()
+    if not row:
+        raise HTTPException(status_code=404, detail="template not found")
+    name, app_type, stored_path = row
+
+    app_id = str(uuid.uuid4())
+    app_dir = os.path.join(UPLOAD_DIR, app_id)
+    shutil.copytree(os.path.join(TEMPLATE_DIR, template_id), app_dir)
+
+    log_path = os.path.join(LOG_DIR, f"{app_id}.log")
+    if not AVAILABLE_PORTS:
+        raise HTTPException(status_code=503, detail="no available ports")
+    port = None
+    while AVAILABLE_PORTS:
+        candidate = AVAILABLE_PORTS.pop()
+        if is_port_free(candidate):
+            port = candidate
+            break
+    if port is None:
+        raise HTTPException(status_code=503, detail="no available ports")
+
+    url = f"/apps/{app_id}/"
+    save_status(
+        app_id,
+        "uploaded",
+        log_path,
+        port=port,
+        name=name,
+        url=url,
+        app_type=app_type,
+    )
+
+    run_path = os.path.join(app_dir, stored_path) if stored_path and stored_path != "." else app_dir
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{AGENT_URL}/run",
+                json={
+                    "app_id": app_id,
+                    "path": run_path,
+                    "type": app_type,
+                    "log_path": log_path,
+                    "port": port,
+                    "allow_ips": None,
+                    "auth_header": None,
+                },
+                timeout=5,
+            )
+            resp.raise_for_status()
+        save_status(app_id, "building", log_path, app_type=app_type)
+    except httpx.ConnectError:
+        AVAILABLE_PORTS.add(port)
+        save_status(app_id, "error", log_path, app_type=app_type)
+        raise HTTPException(status_code=502, detail="Unable to reach agent. Please ensure the agent is running and reachable.")
+    except httpx.TimeoutException:
+        AVAILABLE_PORTS.add(port)
+        save_status(app_id, "error", log_path, app_type=app_type)
+        raise HTTPException(status_code=504, detail="Agent request timed out. Please make sure the agent is running.")
+    except Exception as e:
+        AVAILABLE_PORTS.add(port)
+        save_status(app_id, "error", log_path, app_type=app_type)
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"app_id": app_id, "url": url}
 
 @app.post("/update_status")
 async def update_status(update: StatusUpdate):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,6 +27,7 @@
       const [showLogs, setShowLogs] = useState({});
       const [uploadMsg, setUploadMsg] = useState('');
       const [uploadProgress, setUploadProgress] = useState(0);
+      const [templates, setTemplates] = useState([]);
 
       useEffect(() => {
         fetch('/status')
@@ -34,6 +35,10 @@
           .then(data => {
             setApps(data);
           })
+          .catch(() => {});
+        fetch('/templates')
+          .then(res => res.json())
+          .then(data => setTemplates(data))
           .catch(() => {});
       }, []);
 
@@ -149,6 +154,14 @@
           .catch(() => {});
       };
 
+      const deployTemplate = (id) => {
+        fetch(`/deploy_template/${id}`, { method: 'POST' })
+          .then(() => {
+            refreshStatus();
+          })
+          .catch(() => {});
+      };
+
       return (
         <div>
           <h1 className="text-2xl font-bold mb-4">AI App Portal</h1>
@@ -180,6 +193,19 @@
             </div>
           )}
           {uploadMsg && <p className="text-sm mt-2">{uploadMsg}</p>}
+
+          <div className="bg-white p-4 rounded shadow mb-4">
+            <h2 className="text-xl font-bold mb-2">Templates</h2>
+            {templates.map(t => (
+              <div key={t.id} className="flex justify-between items-center mb-2">
+                <div>
+                  <p className="font-semibold">{t.name}</p>
+                  <p className="text-sm text-gray-600">{t.description}</p>
+                </div>
+                <button onClick={() => deployTemplate(t.id)} className="bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700">Deploy</button>
+              </div>
+            ))}
+          </div>
 
           <div className="grid gap-4">
             {apps.map(app => (


### PR DESCRIPTION
## Summary
- manage templates in SQLite and new directory
- endpoint to upload and list templates
- endpoint to deploy a stored template like an uploaded app
- show templates in the frontend with deploy buttons
- document new functionality in README

## Testing
- `python -m py_compile backend/main.py agent/agent.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a68eadf00832098f955ad7c6d7656