### PR TITLE
Add GPU allocation and display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -214,6 +214,9 @@
                   <div>
                     <h2 className="font-semibold">{app.id}</h2>
                     <p className="text-sm text-gray-600">Status: {app.status}</p>
+                    {app.gpu !== null && app.gpu !== undefined && (
+                      <p className="text-sm text-gray-600">GPU: {app.gpu}</p>
+                    )}
                     {app.url && (
                       <a href={`${nginxBase}${app.url}`} target="_blank" rel="noopener" className="text-blue-600 text-sm underline">Open</a>
                     )}


### PR DESCRIPTION
## Summary
- allocate GPUs in the agent using nvidia-smi and pass CUDA_VISIBLE_DEVICES
- track assigned GPU in the backend DB and expose via `/status`
- show GPU usage for each app in the frontend

## Testing
- `flake8` *(fails: command not found)*
- `python -m py_compile backend/main.py agent/agent.py proxy/proxy.py`

------
https://chatgpt.com/codex/tasks/task_b_685b6069a7208320a1a5dd63b30d9ee8