### PR TITLE
Add fallback when GPU unavailable

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -7,7 +7,7 @@ import sys
 import httpx
 import asyncio
 import socket
-from typing import List, Optional
+from typing import List, Optional, Set
 from proxy.proxy import add_route, remove_route
 import threading
 import time
@@ -20,6 +20,36 @@ app = FastAPI()
 
 PROCESSES = {}
 
+
+def get_available_gpu() -> Optional[int]:
+    """Return an available GPU index based on memory usage."""
+    used: Set[int] = {info.get("gpu") for info in PROCESSES.values() if info.get("gpu") is not None}
+    try:
+        output = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            encoding="utf-8",
+        )
+        candidates = []
+        for line in output.splitlines():
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) != 2:
+                continue
+            idx = int(parts[0])
+            mem = int(parts[1])
+            if idx in used:
+                mem += 10**9  # discourage assigning used GPU
+            candidates.append((mem, idx))
+        if candidates:
+            candidates.sort()
+            return candidates[0][1]
+    except Exception:
+        return None
+    return None
+
 class RunRequest(BaseModel):
     app_id: str
     path: str
@@ -29,6 +59,7 @@ class RunRequest(BaseModel):
     auth_header: Optional[str] = None
     port: int
     reuse_image: bool = False
+    gpu: Optional[int] = None
 
 
 
@@ -90,15 +121,29 @@ async def async_run_detached(cmd, log_path, env=None):
 async def run_app(req: RunRequest, background_tasks: BackgroundTasks):
     # configure the proxy for the assigned port and start build/run in background
     add_route(req.app_id, req.port, req.allow_ips, req.auth_header)
+    gpu = get_available_gpu()
+    if gpu is None:
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"{BACKEND_URL}/update_status",
+                    json={"app_id": req.app_id, "status": "error", "gpu": None},
+                    timeout=5,
+                )
+        except Exception:
+            pass
+        remove_route(req.app_id)
+        raise HTTPException(status_code=500, detail="No available GPU")
     try:
         async with httpx.AsyncClient() as client:
             await client.post(
                 f"{BACKEND_URL}/update_status",
-                json={"app_id": req.app_id, "status": "building"},
+                json={"app_id": req.app_id, "status": "building", "gpu": gpu},
                 timeout=5,
             )
     except Exception:
         pass
+    req.gpu = gpu  # type: ignore
     background_tasks.add_task(build_and_run, req)
     return {"detail": "building"}
 
@@ -108,15 +153,29 @@ async def restart_app(req: RunRequest, background_tasks: BackgroundTasks):
     """Restart an app using an existing Docker image."""
     req.reuse_image = True
     add_route(req.app_id, req.port, req.allow_ips, req.auth_header)
+    gpu = get_available_gpu()
+    if gpu is None:
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"{BACKEND_URL}/update_status",
+                    json={"app_id": req.app_id, "status": "error", "gpu": None},
+                    timeout=5,
+                )
+        except Exception:
+            pass
+        remove_route(req.app_id)
+        raise HTTPException(status_code=500, detail="No available GPU")
     try:
         async with httpx.AsyncClient() as client:
             await client.post(
                 f"{BACKEND_URL}/update_status",
-                json={"app_id": req.app_id, "status": "building"},
+                json={"app_id": req.app_id, "status": "building", "gpu": gpu},
                 timeout=5,
             )
     except Exception:
         pass
+    req.gpu = gpu  # type: ignore
     background_tasks.add_task(build_and_run, req)
     return {"detail": "restarting"}
 
@@ -128,9 +187,11 @@ async def wait_for_http_ready(app_id: str, port: int, proc):
         try:
             async with httpx.AsyncClient() as client:
                 await client.get(url, timeout=1)
+                entry = PROCESSES.get(app_id)
+                gpu = entry.get("gpu") if entry else None
                 await client.post(
                     f"{BACKEND_URL}/update_status",
-                    json={"app_id": app_id, "status": "running"},
+                    json={"app_id": app_id, "status": "running", "gpu": gpu},
                     timeout=5,
                 )
                 return
@@ -140,12 +201,24 @@ async def wait_for_http_ready(app_id: str, port: int, proc):
 
 async def build_and_run(req: RunRequest):
     """Build docker image if needed then run the app."""
+    gpu = req.gpu if req.gpu is not None else get_available_gpu()
+    if gpu is None:
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"{BACKEND_URL}/update_status",
+                    json={"app_id": req.app_id, "status": "error", "gpu": None},
+                    timeout=5,
+                )
+        finally:
+            remove_route(req.app_id)
+        return
     if not is_port_free(req.port):
         try:
             async with httpx.AsyncClient() as client:
                 await client.post(
                     f"{BACKEND_URL}/update_status",
-                    json={"app_id": req.app_id, "status": "error"},
+                    json={"app_id": req.app_id, "status": "error", "gpu": None},
                     timeout=5,
                 )
         finally:
@@ -170,12 +243,18 @@ async def build_and_run(req: RunRequest):
             "docker",
             "run",
             "--rm",
-            "--gpus",
-            "all",
+        ]
+        if gpu is not None:
+            run_cmd += ["--gpus", f"device={gpu}"]
+        run_cmd += [
             "-p",
             f"{req.port}:{req.port}",
             "-e",
             f"PORT={req.port}",
+        ]
+        if gpu is not None:
+            run_cmd += ["-e", f"CUDA_VISIBLE_DEVICES={gpu}"]
+        run_cmd += [
             "-e",
             f"ROOT_PATH=/apps/{req.app_id}",
             "--name",
@@ -185,7 +264,11 @@ async def build_and_run(req: RunRequest):
         proc = await async_run_detached(
             run_cmd,
             req.log_path,
-            env={"PORT": str(req.port), "ROOT_PATH": f"/apps/{req.app_id}"},
+            env={
+                "PORT": str(req.port),
+                "ROOT_PATH": f"/apps/{req.app_id}",
+                **({"CUDA_VISIBLE_DEVICES": str(gpu)} if gpu is not None else {}),
+            },
         )
     elif req.type == "docker_tar":
         run_image = req.app_id
@@ -228,12 +311,18 @@ async def build_and_run(req: RunRequest):
             "docker",
             "run",
             "--rm",
-            "--gpus",
-            "all",           
+        ]
+        if gpu is not None:
+            run_cmd += ["--gpus", f"device={gpu}"]
+        run_cmd += [
             "-p",
             f"{req.port}:{req.port}",
             "-e",
             f"PORT={req.port}",
+        ]
+        if gpu is not None:
+            run_cmd += ["-e", f"CUDA_VISIBLE_DEVICES={gpu}"]
+        run_cmd += [
             "-e",
             f"ROOT_PATH=/apps/{req.app_id}",
             "--name",
@@ -243,7 +332,11 @@ async def build_and_run(req: RunRequest):
         proc = await async_run_detached(
             run_cmd,
             req.log_path,
-            env={"PORT": str(req.port), "ROOT_PATH": f"/apps/{req.app_id}"},
+            env={
+                "PORT": str(req.port),
+                "ROOT_PATH": f"/apps/{req.app_id}",
+                **({"CUDA_VISIBLE_DEVICES": str(gpu)} if gpu is not None else {}),
+            },
         )
     else:  # gradio
         py_files = [f for f in os.listdir(req.path) if f.endswith(".py")]
@@ -263,12 +356,16 @@ async def build_and_run(req: RunRequest):
         proc = await async_run_detached(
             cmd,
             req.log_path,
-            env={"PORT": str(req.port), "ROOT_PATH": f"/apps/{req.app_id}"},
+            env={
+                "PORT": str(req.port),
+                "ROOT_PATH": f"/apps/{req.app_id}",
+                **({"CUDA_VISIBLE_DEVICES": str(gpu)} if gpu is not None else {}),
+            },
         )
 
     # Store the process along with the type so that cleanup can behave
     # differently for docker vs gradio apps
-    PROCESSES[req.app_id] = {"proc": proc, "type": req.type}
+    PROCESSES[req.app_id] = {"proc": proc, "type": req.type, "gpu": gpu}
     asyncio.create_task(heartbeat_loop(req.app_id))
     asyncio.create_task(wait_for_http_ready(req.app_id, req.port, proc))
 
@@ -305,7 +402,7 @@ async def heartbeat_loop(app_id: str):
                 async with httpx.AsyncClient() as client:
                     await client.post(
                         f"{BACKEND_URL}/update_status",
-                        json={"app_id": app_id, "status": status},
+                        json={"app_id": app_id, "status": status, "gpu": None},
                         timeout=5,
                     )
             except Exception:
@@ -361,7 +458,7 @@ async def stop_app(req: StopRequest):
         async with httpx.AsyncClient() as client:
             await client.post(
                 f"{BACKEND_URL}/update_status",
-                json={"app_id": req.app_id, "status": "stopped"},
+                json={"app_id": req.app_id, "status": "stopped", "gpu": None},
                 timeout=5,
             )
     except Exception:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -214,6 +214,9 @@
                   <div>
                     <h2 className="font-semibold">{app.id}</h2>
                     <p className="text-sm text-gray-600">Status: {app.status}</p>
+                    {app.gpu !== null && app.gpu !== undefined && (
+                      <p className="text-sm text-gray-600">GPU: {app.gpu}</p>
+                    )}
                     {app.url && (
                       <a href={`${nginxBase}${app.url}`} target="_blank" rel="noopener" className="text-blue-600 text-sm underline">Open</a>
                     )}


### PR DESCRIPTION
## Summary
- return `None` if GPU cannot be detected
- don't attempt to run apps when no GPU is available
- skip GPU args and env variables when running without a GPU

## Testing
- `python -m py_compile backend/main.py agent/agent.py proxy/proxy.py`
- `flake8` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_685b6069a7208320a1a5dd63b30d9ee8