### PR TITLE
Remove CUDA env var and document GPU mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ The agent builds and runs Docker or Gradio apps and reports status back to the b
 When launching Docker images manually, ensure GPU access is enabled. Install the
 `nvidia-container-toolkit` and run containers with `--gpus all` (or
 `--runtime=nvidia` on older Docker versions) so frameworks like PyTorch can find
-CUDA.
+CUDA. If you want to target a specific GPU, use `--gpus device=N`. Docker maps
+the chosen GPU to `CUDA_VISIBLE_DEVICES=0` inside the container.
 
 The backend specifies a port for each app which the agent forwards to Docker or sets as the `PORT` environment variable for Gradio scripts. Docker apps should listen on the port indicated by this variable. The proxy now rewrites incoming requests so frameworks like Gradio no longer need a `root_path` argument. The agent still sets `ROOT_PATH` for compatibility, but it can be ignored.
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -257,8 +257,6 @@ async def build_and_run(req: RunRequest):
             "-e",
             f"PORT={req.port}",
         ]
-        if gpu is not None:
-            run_cmd += ["-e", f"CUDA_VISIBLE_DEVICES={gpu}"]
         run_cmd += [
             "-e",
             f"ROOT_PATH=/apps/{req.app_id}",
@@ -272,7 +270,6 @@ async def build_and_run(req: RunRequest):
             env={
                 "PORT": str(req.port),
                 "ROOT_PATH": f"/apps/{req.app_id}",
-                **({"CUDA_VISIBLE_DEVICES": str(gpu)} if gpu is not None else {}),
 
             },
         )
@@ -327,8 +324,6 @@ async def build_and_run(req: RunRequest):
             "-e",
             f"PORT={req.port}",
         ]
-        if gpu is not None:
-            run_cmd += ["-e", f"CUDA_VISIBLE_DEVICES={gpu}"]
         run_cmd += [
             "-e",
             f"ROOT_PATH=/apps/{req.app_id}",
@@ -342,7 +337,6 @@ async def build_and_run(req: RunRequest):
             env={
                 "PORT": str(req.port),
                 "ROOT_PATH": f"/apps/{req.app_id}",
-                **({"CUDA_VISIBLE_DEVICES": str(gpu)} if gpu is not None else {}),
 
             },
         )
@@ -367,7 +361,6 @@ async def build_and_run(req: RunRequest):
             env={
                 "PORT": str(req.port),
                 "ROOT_PATH": f"/apps/{req.app_id}",
-                **({"CUDA_VISIBLE_DEVICES": str(gpu)} if gpu is not None else {}),
 
             },
         )


### PR DESCRIPTION
## Summary
- simplify Docker run environment by removing `CUDA_VISIBLE_DEVICES` handling
- note in README that `--gpus device=N` exposes the selected GPU as device 0

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685bb839d0b8832099f59271f503e564