### PR TITLE
Fix template deployment and add editing

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -441,7 +441,7 @@ async def stop_app(req: StopRequest):
     try:
         proc.terminate()
         try:
-            await asyncio.wait_for(proc.wait(), 10)
+            await asyncio.wait_for(proc.wait(), 30)
         except (asyncio.TimeoutError, subprocess.TimeoutExpired):
             proc.kill()
         except Exception:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,10 @@
       const [editId, setEditId] = useState(null);
       const [editName, setEditName] = useState('');
       const [editDesc, setEditDesc] = useState('');
+      const [tEditId, setTEditId] = useState(null);
+      const [tEditName, setTEditName] = useState('');
+      const [tEditDesc, setTEditDesc] = useState('');
+      const [tEditVram, setTEditVram] = useState('0');
 
       useEffect(() => {
         fetch('/status')
@@ -189,6 +193,38 @@
           .catch(() => {});
       };
 
+      const startTemplateEdit = (t) => {
+        setTEditId(t.id);
+        setTEditName(t.name || '');
+        setTEditDesc(t.description || '');
+        setTEditVram(String(t.vram_required || 0));
+      };
+
+      const cancelTemplateEdit = () => {
+        setTEditId(null);
+        setTEditName('');
+        setTEditDesc('');
+        setTEditVram('0');
+      };
+
+      const saveTemplateEdit = () => {
+        fetch('/edit_template', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            template_id: tEditId,
+            name: tEditName,
+            description: tEditDesc,
+            vram_required: parseInt(tEditVram, 10) || 0
+          })
+        }).then(() => {
+          fetch('/templates')
+            .then(res => res.json())
+            .then(data => setTemplates(data));
+          cancelTemplateEdit();
+        }).catch(() => {});
+      };
+
 
       const startEdit = (app) => {
         setEditId(app.id);
@@ -252,17 +288,31 @@
           <div className="bg-white p-4 rounded shadow mb-4">
             <h2 className="text-xl font-bold mb-2">Templates</h2>
             {templates.map(t => (
-              <div key={t.id} className="flex justify-between items-center mb-2">
-                <div>
-                  <p className="font-semibold">{t.name}</p>
-                  <p className="text-sm text-gray-600">{t.description}</p>
-                  <p className="text-sm text-gray-600">Type: {t.type}</p>
-                  <p className="text-sm text-gray-600">VRAM: {t.vram_required}</p>
+              <div key={t.id} className="flex flex-col mb-2">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <p className="font-semibold">{t.name}</p>
+                    <p className="text-sm text-gray-600">{t.description}</p>
+                    <p className="text-sm text-gray-600">Type: {t.type}</p>
+                    <p className="text-sm text-gray-600">VRAM: {t.vram_required}</p>
+                  </div>
+                  <div className="space-x-2">
+                    <button onClick={() => deployTemplate(t.id)} className="bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700">Deploy</button>
+                    <button onClick={() => startTemplateEdit(t)} className="bg-gray-200 px-3 py-1 rounded text-sm hover:bg-gray-300">Edit</button>
+                    <button onClick={() => deleteTemplate(t.id)} className="bg-red-200 px-3 py-1 rounded text-sm hover:bg-red-300">Delete</button>
+                  </div>
                 </div>
-                <div className="space-x-2">
-                  <button onClick={() => deployTemplate(t.id)} className="bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700">Deploy</button>
-                  <button onClick={() => deleteTemplate(t.id)} className="bg-red-200 px-3 py-1 rounded text-sm hover:bg-red-300">Delete</button>
-                </div>
+                {tEditId === t.id && (
+                  <div className="mt-2 space-y-2">
+                    <input type="text" className="border p-1 w-full" value={tEditName} onChange={e => setTEditName(e.target.value)} />
+                    <input type="text" className="border p-1 w-full" value={tEditDesc} onChange={e => setTEditDesc(e.target.value)} />
+                    <input type="number" className="border p-1 w-full" value={tEditVram} onChange={e => setTEditVram(e.target.value)} />
+                    <div className="space-x-2">
+                      <button onClick={saveTemplateEdit} className="bg-blue-600 text-white px-2 py-1 rounded">Save</button>
+                      <button onClick={cancelTemplateEdit} className="bg-gray-200 px-2 py-1 rounded">Cancel</button>
+                    </div>
+                  </div>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- include description when deploying templates
- allow editing template metadata via new endpoint and frontend UI
- show template descriptions when deploying
- extend stop wait time in agent to 30 seconds

## Testing
- `python -m py_compile agent/agent.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_b_685e23279e7c83208d3b97e1aafa8c74