### PR TITLE
Switch frontend scripts to ESM imports

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,9 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>App Portal</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
+  <script type="module">
+    import React from 'https://esm.sh/react@18';
+    import ReactDOM from 'https://esm.sh/react-dom@18';
+    import * as ReactRouterDOM from 'https://esm.sh/react-router-dom@6';
+
+    window.React = React;
+    window.ReactDOM = ReactDOM;
+    window.ReactRouterDOM = ReactRouterDOM;
+  </script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="bg-gray-100 min-h-screen">


### PR DESCRIPTION
## Summary
- load React, ReactDOM and React Router DOM via `https://esm.sh`
- expose those modules globally for the Babel JSX script

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e4a7ae7088320a1bc43a0b0006b58