### PR TITLE
Add flake8 and pytest requirements with example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ pip install -r requirements.txt
 Running `flake8` (or another linter) before committing is recommended to catch
 style issues early. This tool may need to be installed locally.
 
+After installing the requirements you can run the linter and tests:
+
+```bash
+flake8
+pytest
+```
+
 ## Prerequisites
 
 - Python 3 with the following packages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 httpx
+flake8
+pytest

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+
+def test_status_returns_200():
+    with TestClient(app) as client:
+        response = client.get("/status")
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add `flake8` and `pytest` to requirements
- add an example FastAPI test
- document running `flake8` and `pytest` in README

## Testing
- `flake8 .` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_685e4cf1da308320a029fc5b1ddfc362