### PR TITLE
Fix SPA refresh not-found

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1025,3 +1025,9 @@ async def startup_event():
 
 
 # Example: run with `uvicorn backend.main:app --reload`
+
+
+@app.get("/{path:path}", include_in_schema=False)
+async def spa_fallback(path: str):
+    """Serve index.html for client-side routes."""
+    return FileResponse("frontend/index.html")


### PR DESCRIPTION
## Summary
- return the React index.html for client-side routes so `/apps` doesn't 404 on refresh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68633730c734832081e11ad4e420b65a