### PR TITLE
Improve input focus and edit feedback

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -323,6 +323,7 @@
       };
 
       const deleteApp = (id) => {
+        if (!confirm('Delete this app?')) return;
         fetch(`/apps/${id}`, { method: 'DELETE' })
           .then(() => {
             refreshStatus();
@@ -348,6 +349,7 @@
       };
 
       const deleteTemplate = (id) => {
+        if (!confirm('Delete this template?')) return;
         fetch(`/templates/${id}`, { method: 'DELETE' })
           .then(() => {
             fetch('/templates')
@@ -472,7 +474,7 @@
                           <label className="block text-sm font-medium text-gray-700 mb-2">App Name</label>
                           <input 
                             type="text" 
-                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-200" 
+                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200"
                             placeholder="My Awesome AI App" 
                             value={name} 
                             onChange={e => setName(e.target.value)} 
@@ -482,7 +484,7 @@
                         <div>
                           <label className="block text-sm font-medium text-gray-700 mb-2">Description</label>
                           <textarea 
-                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-200 resize-none" 
+                            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 resize-none" 
                             placeholder="Brief description of your app..." 
                             rows="3"
                             value={description} 
@@ -494,7 +496,7 @@
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-2">Runtime</label>
                             <select 
-                              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-200" 
+                              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200" 
                               value={runType} 
                               onChange={e => setRunType(e.target.value)}
                             >
@@ -507,7 +509,7 @@
                             <label className="block text-sm font-medium text-gray-700 mb-2">VRAM (MB)</label>
                             <input 
                               type="number" 
-                              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-200" 
+                              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200" 
                               placeholder="0" 
                               value={vramRequired} 
                               onChange={e => setVramRequired(e.target.value)} 
@@ -597,27 +599,36 @@
                             <div key={t.id} className="border border-gray-200 rounded-lg p-4 hover:border-indigo-300 transition-all duration-200">
                               {tEditId === t.id ? (
                                 <div className="space-y-3">
-                                  <input 
-                                    type="text" 
-                                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-transparent" 
-                                    placeholder="Template Name" 
-                                    value={tEditName} 
-                                    onChange={e => setTEditName(e.target.value)} 
-                                  />
-                                  <textarea 
-                                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none" 
-                                    placeholder="Description" 
-                                    rows="2"
-                                    value={tEditDesc} 
-                                    onChange={e => setTEditDesc(e.target.value)} 
-                                  />
-                                  <input 
-                                    type="number" 
-                                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-transparent" 
-                                    placeholder="VRAM (MB)" 
-                                    value={tEditVram} 
-                                    onChange={e => setTEditVram(e.target.value)} 
-                                  />
+                                  <div className="space-y-1">
+                                    <label className="text-sm text-gray-700">Editing Name</label>
+                                    <input
+                                      type="text"
+                                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                                      placeholder="Template Name"
+                                      value={tEditName}
+                                      onChange={e => setTEditName(e.target.value)}
+                                    />
+                                  </div>
+                                  <div className="space-y-1">
+                                    <label className="text-sm text-gray-700">Editing Description</label>
+                                    <textarea
+                                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 resize-none"
+                                      placeholder="Description"
+                                      rows="2"
+                                      value={tEditDesc}
+                                      onChange={e => setTEditDesc(e.target.value)}
+                                    />
+                                  </div>
+                                  <div className="space-y-1">
+                                    <label className="text-sm text-gray-700">Editing VRAM (MB)</label>
+                                    <input
+                                      type="number"
+                                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                                      placeholder="VRAM (MB)"
+                                      value={tEditVram}
+                                      onChange={e => setTEditVram(e.target.value)}
+                                    />
+                                  </div>
                                   <div className="flex space-x-2">
                                     <button 
                                       onClick={saveTemplateEdit} 
@@ -773,20 +784,26 @@
                           
                           {editId === app.id ? (
                             <div className="space-y-3 mt-4" onClick={e => e.stopPropagation()}>
-                              <input
-                                type="text"
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-                                placeholder="App Name"
-                                value={editName}
-                                onChange={e => setEditName(e.target.value)}
-                              />
-                              <textarea
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none"
-                                placeholder="Description"
-                                rows="2"
-                                value={editDesc}
-                                onChange={e => setEditDesc(e.target.value)}
-                              />
+                              <div className="space-y-1">
+                                <label className="text-sm text-gray-700">Editing Name</label>
+                                <input
+                                  type="text"
+                                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                                  placeholder="App Name"
+                                  value={editName}
+                                  onChange={e => setEditName(e.target.value)}
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <label className="text-sm text-gray-700">Editing Description</label>
+                                <textarea
+                                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 resize-none"
+                                  placeholder="Description"
+                                  rows="2"
+                                  value={editDesc}
+                                  onChange={e => setEditDesc(e.target.value)}
+                                />
+                              </div>
                               <div className="flex space-x-2">
                                 <button
                                   onClick={saveEdit}


### PR DESCRIPTION
## Summary
- highlight focused form controls with a single indigo border
- show which fields are being edited for apps and templates
- ask for confirmation before deleting apps or templates

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68637cab4c088320aaf4c95b7ea09a71