### PR TITLE
Add simple JWT auth system

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,25 @@ On the frontend the templates are loaded on page load and displayed with a **Dep
 Each uploaded app also shows a **Save Template** button to store it for future reuse.
 Templates display their name, description, type and VRAM, along with a **Delete** button to remove them.
 
+## Authentication
+
+Create a user account via the `/register` endpoint:
+
+```bash
+curl -X POST -F "username=myuser" -F "password=mypass" http://localhost:8000/register
+```
+
+Then obtain a token using `/login`:
+
+```bash
+curl -X POST -d "username=myuser&password=mypass" http://localhost:8000/login
+```
+
+The response contains an `access_token` that must be included in the `Authorization` header when calling protected endpoints like `/upload` or `/templates`:
+
+```bash
+Authorization: Bearer <token>
+```
+
+The React frontend now prompts for login on first visit and stores the token in `localStorage`.
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,17 @@
 """FastAPI backend for MLOps app deployment."""
-from fastapi import FastAPI, UploadFile, File, HTTPException, Form, BackgroundTasks
+from fastapi import (
+    FastAPI,
+    UploadFile,
+    File,
+    HTTPException,
+    Form,
+    BackgroundTasks,
+    Depends,
+    status,
+)
 from fastapi.responses import PlainTextResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 import shutil
 import os
@@ -13,6 +23,9 @@ import re
 import time
 import asyncio
 import socket
+from datetime import datetime, timedelta
+from jose import JWTError, jwt
+from passlib.context import CryptContext
 
 DATABASE = "./app.db"
 UPLOAD_DIR = "./uploads"
@@ -26,6 +39,13 @@ PORT_END = int(os.environ.get("PORT_END", 9100))
 AVAILABLE_PORTS = set(range(PORT_START, PORT_END))
 app = FastAPI()
 
+# Authentication setup
+SECRET_KEY = os.environ.get("SECRET_KEY", "change_me")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
 # Serve the React frontend from the same origin
 app.mount("/static", StaticFiles(directory="frontend"), name="frontend")
 
@@ -36,6 +56,64 @@ async def frontend_index():
 
 # Allowed pattern for uploaded filenames
 ALLOWED_FILENAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return pwd_context.verify(password, hashed)
+
+
+def create_access_token(
+    data: dict, expires_delta: timedelta | None = None
+) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_user(username: str):
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute("SELECT id, username, password_hash FROM users WHERE username=?", (username,))
+    row = c.fetchone()
+    conn.close()
+    if row:
+        return {"id": row[0], "username": row[1], "password_hash": row[2]}
+    return None
+
+
+def authenticate_user(username: str, password: str):
+    user = get_user(username)
+    if not user:
+        return None
+    if not verify_password(password, user["password_hash"]):
+        return None
+    return user
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = get_user(username)
+    if user is None:
+        raise credentials_exception
+    return user
 
 def init_db():
     conn = sqlite3.connect(DATABASE)
@@ -68,6 +146,15 @@ def init_db():
             path TEXT,
             description TEXT,
             vram_required INTEGER
+        )
+        """
+    )
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE,
+            password_hash TEXT
         )
         """
     )
@@ -157,6 +244,35 @@ def is_port_free(port: int) -> bool:
         return False
     finally:
         s.close()
+
+
+@app.post("/register")
+async def register(username: str = Form(...), password: str = Form(...)):
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute("SELECT id FROM users WHERE username=?", (username,))
+    if c.fetchone():
+        conn.close()
+        raise HTTPException(status_code=400, detail="username already exists")
+    c.execute(
+        "INSERT INTO users(username, password_hash) VALUES(?, ?)",
+        (username, get_password_hash(password)),
+    )
+    conn.commit()
+    conn.close()
+    return {"detail": "user created"}
+
+
+@app.post("/login")
+async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+        )
+    access_token = create_access_token({"sub": user["username"]})
+    return {"access_token": access_token, "token_type": "bearer"}
 
 class StatusUpdate(BaseModel):
     app_id: str
@@ -262,6 +378,7 @@ async def upload_app(
     allow_ips: str = Form(None),
     auth_header: str = Form(None),
     vram_required: int = Form(0),
+    current_user: dict = Depends(get_current_user),
 ):
 
     """Receive user uploaded app and trigger agent build/run."""
@@ -422,6 +539,7 @@ async def upload_template(
     file: UploadFile = File(...),
     description: str = Form(""),
     vram_required: int = Form(0),
+    current_user: dict = Depends(get_current_user),
 ):
     """Upload a template archive or file."""
     template_id = str(uuid.uuid4())
@@ -919,7 +1037,7 @@ class EditTemplate(BaseModel):
 
 
 @app.post("/edit_app")
-async def edit_app(info: EditApp):
+async def edit_app(info: EditApp, current_user: dict = Depends(get_current_user)):
     """Update app name and description."""
     conn = sqlite3.connect(DATABASE)
     c = conn.cursor()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -148,6 +148,15 @@
     
     const nginxBase = window.location.protocol + '//' + window.location.hostname + ':8080';
 
+    const apiFetch = (url, options = {}) => {
+      const token = localStorage.getItem('token');
+      options.headers = options.headers || {};
+      if (token) {
+        options.headers['Authorization'] = 'Bearer ' + token;
+      }
+      return fetch(url, options);
+    };
+
     // 커스텀 드롭다운 컴포넌트
     const CustomSelect = ({ options, value, onChange, placeholder = "Select..." }) => {
       const [isOpen, setIsOpen] = useState(false);
@@ -266,6 +275,9 @@
     // Main App Component
     function AppRoutes() {
       const location = useLocation();
+      const [token, setToken] = useState(localStorage.getItem('token') || '');
+      const [username, setUsername] = useState('');
+      const [password, setPassword] = useState('');
       const [name, setName] = useState('');
       const [description, setDescription] = useState('');
       const [runType, setRunType] = useState('gradio');
@@ -292,27 +304,59 @@
         return () => document.removeEventListener('click', handleClickOutside);
       }, []);
 
+      if (!token) {
+        const handleLogin = (e) => {
+          e.preventDefault();
+          apiFetch('/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ username, password })
+          })
+            .then(res => res.json())
+            .then(data => {
+              if (data.access_token) {
+                localStorage.setItem('token', data.access_token);
+                setToken(data.access_token);
+              } else {
+                alert('Login failed');
+              }
+            })
+            .catch(() => alert('Login failed'));
+        };
+
+        return (
+          <div className="min-h-screen flex items-center justify-center bg-gray-100">
+            <form onSubmit={handleLogin} className="bg-white p-6 rounded-lg shadow space-y-4">
+              <h2 className="text-xl font-semibold text-gray-900">Login</h2>
+              <input type="text" className="w-full border rounded p-2" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+              <input type="password" className="w-full border rounded p-2" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+              <button type="submit" className="btn-primary text-white w-full py-2 rounded">Login</button>
+            </form>
+          </div>
+        );
+      }
+
 
       useEffect(() => {
-        fetch('/status')
+        apiFetch('/status')
           .then(res => res.json())
           .then(data => setApps(data))
           .catch(() => {});
-        fetch('/templates')
+        apiFetch('/templates')
           .then(res => res.json())
           .then(data => setTemplates(data))
           .catch(() => {});
       }, []);
 
       const refreshStatus = () => {
-        fetch('/status')
+        apiFetch('/status')
           .then(res => res.json())
           .then(data => setApps(data));
       };
 
       const pollStatus = (appId) => {
         const interval = setInterval(() => {
-          fetch('/status')
+          apiFetch('/status')
             .then(res => res.json())
             .then(data => {
               setApps(data);
@@ -343,6 +387,10 @@
         formData.append('vram_required', vramRequired);
         const xhr = new XMLHttpRequest();
         xhr.open('POST', '/upload');
+        const t = localStorage.getItem('token');
+        if (t) {
+          xhr.setRequestHeader('Authorization', 'Bearer ' + t);
+        }
         setUploadMsg('Upload started');
         xhr.upload.onprogress = (event) => {
           if (event.lengthComputable) {
@@ -377,7 +425,7 @@
           setShowLogs(prev => ({ ...prev, [appId]: false }));
           return;
         }
-        fetch(`/logs/${appId}`)
+        apiFetch(`/logs/${appId}`)
           .then(res => res.text())
           .then(text => {
             setLogs(prev => ({ ...prev, [appId]: text }));
@@ -398,7 +446,7 @@
       };
 
       const stopApp = (id) => {
-        fetch(`/stop/${id}`, { method: 'POST' })
+        apiFetch(`/stop/${id}`, { method: 'POST' })
           .then(() => {
             refreshStatus();
             pollStatus(id);
@@ -407,14 +455,14 @@
       };
 
       const restartApp = (id) => {
-        fetch(`/restart/${id}`, { method: 'POST' })
+        apiFetch(`/restart/${id}`, { method: 'POST' })
           .then(() => refreshStatus())
           .catch(() => {});
       };
 
       const deleteApp = (id) => {
         if (!confirm('Delete this app?')) return;
-        fetch(`/apps/${id}`, { method: 'DELETE' })
+        apiFetch(`/apps/${id}`, { method: 'DELETE' })
           .then(() => {
             refreshStatus();
             setLogs(prev => { const n = { ...prev }; delete n[id]; return n; });
@@ -423,15 +471,15 @@
       };
 
       const deployTemplate = (id) => {
-        fetch(`/deploy_template/${id}`, { method: 'POST' })
+        apiFetch(`/deploy_template/${id}`, { method: 'POST' })
           .then(() => refreshStatus())
           .catch(() => {});
       };
 
       const saveTemplate = (id) => {
-        fetch(`/save_template/${id}`, { method: 'POST' })
+        apiFetch(`/save_template/${id}`, { method: 'POST' })
           .then(() => {
-            fetch('/templates')
+            apiFetch('/templates')
               .then(res => res.json())
               .then(data => setTemplates(data));
           })
@@ -440,9 +488,9 @@
 
       const deleteTemplate = (id) => {
         if (!confirm('Delete this template?')) return;
-        fetch(`/templates/${id}`, { method: 'DELETE' })
+        apiFetch(`/templates/${id}`, { method: 'DELETE' })
           .then(() => {
-            fetch('/templates')
+            apiFetch('/templates')
               .then(res => res.json())
               .then(data => setTemplates(data));
           })
@@ -464,7 +512,7 @@
       };
 
       const saveTemplateEdit = () => {
-        fetch('/edit_template', {
+        apiFetch('/edit_template', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -474,7 +522,7 @@
             vram_required: parseInt(tEditVram, 10) || 0
           })
         }).then(() => {
-          fetch('/templates')
+          apiFetch('/templates')
             .then(res => res.json())
             .then(data => setTemplates(data));
           cancelTemplateEdit();
@@ -494,7 +542,7 @@
       };
 
       const saveEdit = () => {
-        fetch('/edit_app', {
+        apiFetch('/edit_app', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ app_id: editId, name: editName, description: editDesc })
@@ -520,26 +568,32 @@
                 </div>
                 
                 <nav className="flex space-x-1 bg-gray-100 rounded-lg p-1">
-                  <Link 
-                    to="/" 
+                  <Link
+                    to="/"
                     className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
-                      location.pathname === '/' 
-                        ? 'bg-white text-gray-900 shadow-sm' 
+                      location.pathname === '/'
+                        ? 'bg-white text-gray-900 shadow-sm'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
                     Create App
                   </Link>
-                  <Link 
-                    to="/apps" 
+                  <Link
+                    to="/apps"
                     className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
-                      location.pathname === '/apps' 
-                        ? 'bg-white text-gray-900 shadow-sm' 
+                      location.pathname === '/apps'
+                        ? 'bg-white text-gray-900 shadow-sm'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
                     My Apps ({apps.length})
                   </Link>
+                  <button
+                    onClick={() => { localStorage.removeItem('token'); setToken(''); }}
+                    className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900"
+                  >
+                    Logout
+                  </button>
                 </nav>
               </div>
             </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 httpx
+passlib[bcrypt]
+python-jose


### PR DESCRIPTION
## Summary
- create users table and auth helpers in backend
- add `/register` and `/login` endpoints issuing JWT tokens
- protect upload and edit routes with token validation
- implement login UI in React frontend and attach Authorization header
- document how to register and login
- add auth dependencies

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_b_686398f654c08320a48f37a231f4c27b