### PR TITLE
Fix login render and add admin user management

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -82,11 +82,11 @@ def create_access_token(
 def get_user(username: str):
     conn = sqlite3.connect(DATABASE)
     c = conn.cursor()
-    c.execute("SELECT id, username, password_hash FROM users WHERE username=?", (username,))
+    c.execute("SELECT id, username, password_hash, is_admin FROM users WHERE username=?", (username,))
     row = c.fetchone()
     conn.close()
     if row:
-        return {"id": row[0], "username": row[1], "password_hash": row[2]}
+        return {"id": row[0], "username": row[1], "password_hash": row[2], "is_admin": bool(row[3])}
     return None
 
 
@@ -294,6 +294,50 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends()):
         )
     access_token = create_access_token({"sub": user["username"]})
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.get("/users/me")
+async def get_me(current_user: dict = Depends(get_current_user)):
+    return {
+        "id": current_user["id"],
+        "username": current_user["username"],
+        "is_admin": current_user.get("is_admin", False),
+    }
+
+
+@app.get("/users")
+async def list_users(current_user: dict = Depends(get_current_user)):
+    if not current_user.get("is_admin"):
+        raise HTTPException(status_code=403, detail="admin only")
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute("SELECT id, username, is_admin FROM users")
+    users = [
+        {"id": row[0], "username": row[1], "is_admin": bool(row[2])}
+        for row in c.fetchall()
+    ]
+    conn.close()
+    return users
+
+
+@app.delete("/users/{user_id}")
+async def delete_user(user_id: int, current_user: dict = Depends(get_current_user)):
+    if not current_user.get("is_admin"):
+        raise HTTPException(status_code=403, detail="admin only")
+    conn = sqlite3.connect(DATABASE)
+    c = conn.cursor()
+    c.execute("SELECT username FROM users WHERE id=?", (user_id,))
+    row = c.fetchone()
+    if not row:
+        conn.close()
+        raise HTTPException(status_code=404, detail="user not found")
+    if row[0] == "admin":
+        conn.close()
+        raise HTTPException(status_code=400, detail="cannot delete admin user")
+    c.execute("DELETE FROM users WHERE id=?", (user_id,))
+    conn.commit()
+    conn.close()
+    return {"detail": "deleted"}
 
 class StatusUpdate(BaseModel):
     app_id: str

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -284,6 +284,7 @@
       const [vramRequired, setVramRequired] = useState('0');
       const [files, setFiles] = useState([]);
       const [apps, setApps] = useState([]);
+      const [users, setUsers] = useState([]);
       const [logs, setLogs] = useState({});
       const [showLogs, setShowLogs] = useState({});
       const [uploadMsg, setUploadMsg] = useState('');
@@ -297,6 +298,7 @@
       const [tEditDesc, setTEditDesc] = useState('');
       const [tEditVram, setTEditVram] = useState('0');
       const [openMenus, setOpenMenus] = useState({});
+      const [isAdmin, setIsAdmin] = useState(false);
       const [mode, setMode] = useState('login');
       // Close any open kebab menus when clicking outside
       useEffect(() => {
@@ -318,6 +320,8 @@
               if (data.access_token) {
                 localStorage.setItem('token', data.access_token);
                 setToken(data.access_token);
+                // Reload to ensure the main UI renders immediately
+                window.location.href = '/';
               } else {
                 alert('Login failed');
               }
@@ -380,7 +384,11 @@
           .then(res => res.json())
           .then(data => setTemplates(data))
           .catch(() => {});
-      }, []);
+        apiFetch('/users/me')
+          .then(res => res.ok ? res.json() : null)
+          .then(data => { if (data) { setIsAdmin(data.is_admin); } })
+          .catch(() => {});
+      }, [token]);
 
       const refreshStatus = () => {
         apiFetch('/status')
@@ -407,6 +415,15 @@
         const interval = setInterval(refreshStatus, 2000);
         return () => clearInterval(interval);
       }, []);
+
+      useEffect(() => {
+        if (isAdmin) {
+          apiFetch('/users')
+            .then(res => res.json())
+            .then(data => setUsers(data))
+            .catch(() => {});
+        }
+      }, [isAdmin]);
 
       const handleUpload = (e) => {
         e.preventDefault();
@@ -531,6 +548,15 @@
           .catch(() => {});
       };
 
+      const deleteUser = (id) => {
+        if (!confirm('Delete this user?')) return;
+        apiFetch(`/users/${id}`, { method: 'DELETE' })
+          .then(() => {
+            setUsers(prev => prev.filter(u => u.id !== id));
+          })
+          .catch(() => {});
+      };
+
       const startTemplateEdit = (t) => {
         setTEditId(t.id);
         setTEditName(t.name || '');
@@ -622,6 +648,18 @@
                   >
                     My Apps ({apps.length})
                   </Link>
+                  {isAdmin && (
+                    <Link
+                      to="/user-admin"
+                      className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
+                        location.pathname === '/user-admin'
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Users
+                    </Link>
+                  )}
                   <button
                     onClick={() => { localStorage.removeItem('token'); setToken(''); }}
                     className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900"
@@ -1025,6 +1063,33 @@
                   )}
                 </div>
               </Route>
+              {isAdmin && (
+                <Route path="/user-admin">
+                  <div className="space-y-6">
+                    <div className="text-center mb-8">
+                      <h2 className="text-3xl font-bold text-gray-900 mb-2">User Management</h2>
+                    </div>
+                    <div className="bg-white rounded-2xl shadow-xl border border-gray-200/50 p-8">
+                      {users.length === 0 ? (
+                        <p className="text-gray-500">No users.</p>
+                      ) : (
+                        <ul className="space-y-2">
+                          {users.map(u => (
+                            <li key={u.id} className="flex justify-between items-center border rounded px-3 py-2">
+                              <span>{u.username}{u.is_admin ? ' (admin)' : ''}</span>
+                              {!u.is_admin && (
+                                <button onClick={() => deleteUser(u.id)} className="text-red-600 hover:underline">
+                                  Delete
+                                </button>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                </Route>
+              )}
             </Switch>
           </main>
           


### PR DESCRIPTION
## Summary
- reload UI automatically after login succeeds
- display Users link and management screen for admins
- fetch admin flag and user list in frontend
- add backend endpoints for current user info and user deletion

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_b_6863a0168df88320b3b60c3302c9ffd9