### PR TITLE
Improve admin user management

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -284,6 +284,7 @@
       const [vramRequired, setVramRequired] = useState('0');
       const [files, setFiles] = useState([]);
       const [apps, setApps] = useState([]);
+      const [users, setUsers] = useState([]);
       const [logs, setLogs] = useState({});
       const [showLogs, setShowLogs] = useState({});
       const [uploadMsg, setUploadMsg] = useState('');
@@ -297,6 +298,7 @@
       const [tEditDesc, setTEditDesc] = useState('');
       const [tEditVram, setTEditVram] = useState('0');
       const [openMenus, setOpenMenus] = useState({});
+      const [isAdmin, setIsAdmin] = useState(false);
       const [mode, setMode] = useState('login');
       // Close any open kebab menus when clicking outside
       useEffect(() => {
@@ -318,6 +320,9 @@
               if (data.access_token) {
                 localStorage.setItem('token', data.access_token);
                 setToken(data.access_token);
+                if (data.is_admin) setIsAdmin(true);
+                // Reload to ensure the main UI renders immediately
+                window.location.href = '/';
               } else {
                 alert('Login failed');
               }
@@ -380,7 +385,11 @@
           .then(res => res.json())
           .then(data => setTemplates(data))
           .catch(() => {});
-      }, []);
+        apiFetch('/users/me')
+          .then(res => res.ok ? res.json() : null)
+          .then(data => { if (data) { setIsAdmin(data.is_admin); } })
+          .catch(() => {});
+      }, [token]);
 
       const refreshStatus = () => {
         apiFetch('/status')
@@ -407,6 +416,15 @@
         const interval = setInterval(refreshStatus, 2000);
         return () => clearInterval(interval);
       }, []);
+
+      useEffect(() => {
+        if (isAdmin) {
+          apiFetch('/users')
+            .then(res => res.json())
+            .then(data => setUsers(data))
+            .catch(() => {});
+        }
+      }, [isAdmin]);
 
       const handleUpload = (e) => {
         e.preventDefault();
@@ -531,6 +549,26 @@
           .catch(() => {});
       };
 
+      const deleteUser = (id) => {
+        if (!confirm('Delete this user?')) return;
+        apiFetch(`/users/${id}`, { method: 'DELETE' })
+          .then(() => {
+            setUsers(prev => prev.filter(u => u.id !== id));
+          })
+          .catch(() => {});
+      };
+
+      const resetPassword = (id) => {
+        const pwd = prompt('Enter new password');
+        if (!pwd) return;
+        apiFetch(`/users/${id}/reset_password`, {
+          method: 'POST',
+          body: new URLSearchParams({ new_password: pwd })
+        })
+          .then(() => alert('Password reset'))
+          .catch(() => alert('Error resetting password'));
+      };
+
       const startTemplateEdit = (t) => {
         setTEditId(t.id);
         setTEditName(t.name || '');
@@ -596,9 +634,9 @@
                   <div className="w-8 h-8 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-lg flex items-center justify-center">
                     <span className="text-white font-bold text-sm">AI</span>
                   </div>
-                  <h1 className="text-2xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
+                  <Link to="/" className="text-2xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
                     AI App Portal
-                  </h1>
+                  </Link>
                 </div>
                 
                 <nav className="flex space-x-1 bg-gray-100 rounded-lg p-1">
@@ -622,8 +660,24 @@
                   >
                     My Apps ({apps.length})
                   </Link>
+                  {isAdmin && (
+                    <Link
+                      to="/user-admin"
+                      className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
+                        location.pathname === '/user-admin'
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:text-gray-900'
+                      }`}
+                    >
+                      Users
+                    </Link>
+                  )}
                   <button
-                    onClick={() => { localStorage.removeItem('token'); setToken(''); }}
+                    onClick={() => {
+                      localStorage.removeItem('token');
+                      setToken('');
+                      window.location.href = '/';
+                    }}
                     className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900"
                   >
                     Logout
@@ -767,7 +821,7 @@
                         <h2 className="text-xl font-semibold text-gray-900">Quick Deploy Templates</h2>
                       </div>
                       
-                      <div className="space-y-4 max-h-96 overflow-y-auto">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-96 overflow-y-auto">
                         {templates.length === 0 ? (
                           <div className="text-center py-8 text-gray-500">
                             <p>No templates available yet.</p>
@@ -1025,6 +1079,38 @@
                   )}
                 </div>
               </Route>
+              {isAdmin && (
+                <Route path="/user-admin">
+                  <div className="space-y-6">
+                    <div className="text-center mb-8">
+                      <h2 className="text-3xl font-bold text-gray-900 mb-2">User Management</h2>
+                    </div>
+                    <div className="bg-white rounded-2xl shadow-xl border border-gray-200/50 p-8">
+                      {users.length === 0 ? (
+                        <p className="text-gray-500">No users.</p>
+                      ) : (
+                        <ul className="space-y-2">
+                          {users.map(u => (
+                            <li key={u.id} className="flex justify-between items-center border rounded px-3 py-2">
+                              <span>{u.username}{u.is_admin ? ' (admin)' : ''}</span>
+                              <div className="space-x-2">
+                                {!u.is_admin && (
+                                  <button onClick={() => deleteUser(u.id)} className="text-red-600 hover:underline">
+                                    Delete
+                                  </button>
+                                )}
+                                <button onClick={() => resetPassword(u.id)} className="text-blue-600 hover:underline">
+                                  Reset Password
+                                </button>
+                              </div>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                </Route>
+              )}
             </Switch>
           </main>
           


### PR DESCRIPTION
## Summary
- add password reset API for admins
- support resetting passwords from the Users page
- show template cards in two columns

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_b_6863a0168df88320b3b60c3302c9ffd9