### PR TITLE
Fix gradio venv setup and cleanup

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -462,7 +462,8 @@ async def build_and_run(req: RunRequest):
             return
 
         venv_dir = os.path.join(req.path, "venv")
-        ret = await async_run_wait(["python3.10", "-m", "venv", venv_dir], req.log_path)
+        python_exe = sys.executable
+        ret = await async_run_wait([python_exe, "-m", "venv", venv_dir], req.log_path)
         if ret != 0:
             try:
                 async with httpx.AsyncClient() as client:
@@ -477,8 +478,8 @@ async def build_and_run(req: RunRequest):
 
         req_file = os.path.join(req.path, "requirements.txt")
         if os.path.exists(req_file):
-            pip_path = os.path.join(venv_dir, "bin", "pip")
-            ret = await async_run_wait([pip_path, "install", "-r", req_file], req.log_path)
+            python_path = os.path.join(venv_dir, "bin", "python")
+            ret = await async_run_wait([python_path, "-m", "pip", "install", "-r", req_file], req.log_path)
             if ret != 0:
                 try:
                     async with httpx.AsyncClient() as client:

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 import shutil
 import os
+import subprocess
 import uuid
 import zipfile
 import sqlite3
@@ -1187,7 +1188,10 @@ async def delete_app(app_id: str):
     conn.commit()
     conn.close()
 
-    shutil.rmtree(os.path.join(UPLOAD_DIR, app_id), ignore_errors=True)
+    app_path = os.path.join(UPLOAD_DIR, app_id)
+    shutil.rmtree(app_path, ignore_errors=True)
+    if os.path.exists(app_path):
+        subprocess.run(["rm", "-rf", app_path], check=False)
     log_file = os.path.join(LOG_DIR, f"{app_id}.log")
     if os.path.exists(log_file):
         os.remove(log_file)


### PR DESCRIPTION
## Summary
- ensure gradio apps create the virtualenv with the current python
- install requirements via `python -m pip`
- force remove upload directory on app deletion so `venv` doesn't block cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864dfc065088320adba2cbfc2ed7c27