### PR TITLE
Fix admin login persistence and show user info

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -333,6 +333,7 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends()):
         "access_token": access_token,
         "token_type": "bearer",
         "is_admin": bool(user.get("is_admin", False)),
+        "username": user["username"],
     }
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -301,6 +301,7 @@
       const [tEditVram, setTEditVram] = useState('0');
       const [openMenus, setOpenMenus] = useState({});
       const [isAdmin, setIsAdmin] = useState(false);
+      const [currentUser, setCurrentUser] = useState('');
       const [mode, setMode] = useState('login');
       // Close any open kebab menus when clicking outside
       useEffect(() => {
@@ -322,6 +323,7 @@
               if (data.access_token) {
                 localStorage.setItem('token', data.access_token);
                 setToken(data.access_token);
+                setCurrentUser(data.username || '');
                 if (data.is_admin) setIsAdmin(true);
 
                 // Reload to ensure the main UI renders immediately
@@ -390,7 +392,12 @@
           .catch(() => {});
         apiFetch('/users/me')
           .then(res => res.ok ? res.json() : null)
-          .then(data => { if (data) { setIsAdmin(data.is_admin); } })
+          .then(data => {
+            if (data) {
+              setIsAdmin(data.is_admin);
+              setCurrentUser(data.username);
+            }
+          })
           .catch(() => {});
       }, [token]);
 
@@ -697,10 +704,17 @@
                       Users
                     </Link>
                   )}
+                  {currentUser && (
+                    <span className="px-4 py-2 text-sm text-gray-600">
+                      Logged in as {currentUser}
+                    </span>
+                  )}
                   <button
                     onClick={() => {
                       localStorage.removeItem('token');
                       setToken('');
+                      setCurrentUser('');
+                      setIsAdmin(false);
                       window.location.href = '/';
                     }}
                     className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900"


### PR DESCRIPTION
## Summary
- expose username in login response
- keep track of the currently logged in user in the frontend and show it in the header
- clear user info on logout

## Testing
- `python -m py_compile backend/main.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864ecd10380832085c836f6eb05d218