### PR TITLE
Add HF token support in agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ uvicorn agent.agent:app --port 8001
 - `PROXY_LINK_PATH`: path where the agent attempts to symlink the generated
   Nginx config so it is loaded automatically. Defaults to
   `/etc/nginx/conf.d/apps.conf`.
+- `HUGGINGFACE_HUB_TOKEN`: optional token used by the agent when running apps
+  or installing dependencies. Providing it allows apps to download gated models
+  from Hugging Face. The environment variable `HF_TOKEN` is also respected.
 
 ## Proxy configuration
 


### PR DESCRIPTION
## Summary
- allow `agent.build_and_run` to pass `HUGGINGFACE_HUB_TOKEN` and `HF_TOKEN` when launching apps
- document `HUGGINGFACE_HUB_TOKEN` in README

## Testing
- `python -m py_compile agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_b_6864f49972a88320865a2ec6e08b1daa