### PR TITLE
Improve Nginx proxy for video streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_set_header Range $http_range;
+        proxy_set_header If-Range $http_if_range;
+        proxy_buffering off;
     }
 }
 ```

--- a/proxy/nginx_template.conf
+++ b/proxy/nginx_template.conf
@@ -11,6 +11,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Range $http_range;
+        proxy_set_header If-Range $http_if_range;
+        proxy_buffering off;
         # optional IP allowlist
         # allow 192.168.0.0/16;
         # deny all;

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -57,11 +57,14 @@ def generate_config(routes):
         lines.append(f"        proxy_pass http://127.0.0.1:{info['port']}/;")
         lines.append("        proxy_http_version 1.1;")
         lines.append("        proxy_set_header Upgrade $http_upgrade;")
-        lines.append('        proxy_set_header Connection "upgrade";')
+        lines.append('        proxy_set_header Connection \"upgrade\";')
         lines.append("        proxy_set_header Host $host;")
         lines.append("        proxy_set_header X-Real-IP $remote_addr;")
         lines.append("        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;")
         lines.append("        proxy_set_header X-Forwarded-Proto $scheme;")
+        lines.append("        proxy_set_header Range $http_range;")
+        lines.append("        proxy_set_header If-Range $http_if_range;")
+        lines.append("        proxy_buffering off;")
         if info.get("allow_ips"):
             for ip in info["allow_ips"]:
                 lines.append(f"        allow {ip};")


### PR DESCRIPTION
## Summary
- forward Range headers and disable buffering in nginx config to support video playback
- document the new headers in the README

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866226faf588320928d4c4eb38c2d6a