### PR TITLE
Remove manual refresh after template deploy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -596,7 +596,6 @@
           setDeployingApps(prev => [...prev, placeholder]);
           setDeployingTemplates(prev => ({ ...prev, [id]: data.app_id }));
           setApps(prev => [placeholder, ...prev]);
-          refreshStatus();
         } catch {
           setDeployingTemplates(prev => {
             const n = { ...prev };


### PR DESCRIPTION
## Summary
- avoid calling `refreshStatus` in `deployTemplate`

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68662a99b3a0832097b6e8454e2c3135