### PR TITLE
Update template card hover style

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -627,7 +627,7 @@
                                         </div>
                                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-[500px] overflow-y-auto pr-2">
                                             {templates.length > 0 ? templates.map(t => (
-                                                <div key={t.id} className="bg-slate-900/50 border border-slate-700 rounded-lg p-4 hover:border-primary/50 transition-all duration-200 relative">
+                                                <div key={t.id} className="bg-slate-900/50 border border-slate-700 rounded-lg p-4 card-hover cursor-pointer relative">
                                                     <div className="flex justify-between items-start">
                                                         <h3 className="font-semibold text-slate-100">{t.name}</h3>
                                                         <div className="relative z-10" onClick={e => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- ensure templates use `card-hover` style
- remove border highlight on template cards

## Testing
- `flake8` *(fails: not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68678faa22b88320885aca3b815028b1