### PR TITLE
Add thread lock for proxy routes

### DIFF
--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -2,6 +2,7 @@ import os
 import json
 import subprocess
 import logging
+import threading
 
 ROUTES_FILE = os.environ.get(
     "ROUTES_FILE", os.path.join(os.path.dirname(__file__), "routes.json")
@@ -11,6 +12,9 @@ CONFIG_PATH = os.environ.get(
 )
 # Path where nginx will read the config; defaults to /etc/nginx/conf.d/apps.conf
 LINK_PATH = os.environ.get("PROXY_LINK_PATH", "/etc/nginx/conf.d/apps.conf")
+
+# Serialize access to routes and config generation
+ROUTE_LOCK = threading.Lock()
 
 
 def ensure_link():
@@ -88,23 +92,26 @@ def reload_proxy():
 
 
 def add_route(app_id, port, allow_ips=None, auth_header=None):
-    routes = load_routes()
-    routes[app_id] = {"port": port}
-    if allow_ips:
-        routes[app_id]["allow_ips"] = allow_ips
-    if auth_header:
-        routes[app_id]["auth_header"] = auth_header
-    save_routes(routes)
-    generate_config(routes)
-    reload_proxy()
+    """Add a route for an app and reload the proxy."""
+    with ROUTE_LOCK:
+        routes = load_routes()
+        routes[app_id] = {"port": port}
+        if allow_ips:
+            routes[app_id]["allow_ips"] = allow_ips
+        if auth_header:
+            routes[app_id]["auth_header"] = auth_header
+        save_routes(routes)
+        generate_config(routes)
+        reload_proxy()
     return port
 
 
 def remove_route(app_id):
     """Remove an app's route and reload the proxy."""
-    routes = load_routes()
-    if app_id in routes:
-        routes.pop(app_id)
-        save_routes(routes)
-        generate_config(routes)
-        reload_proxy()
+    with ROUTE_LOCK:
+        routes = load_routes()
+        if app_id in routes:
+            routes.pop(app_id)
+            save_routes(routes)
+            generate_config(routes)
+            reload_proxy()


### PR DESCRIPTION
## Summary
- ensure nginx route config is updated atomically
- wrap `add_route` and `remove_route` with a shared lock

## Testing
- `python -m py_compile proxy/proxy.py`
- `python -m py_compile backend/main.py agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_b_686ce002e3448320bd8c7f38109fa144