### PR TITLE
Update GPU selection logic

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -133,8 +133,13 @@ def get_available_gpu(required: int = 0) -> Optional[List[int]]:
             candidates.append((idx, free))
         if not candidates:
             return None
-        candidates.sort(key=lambda t: t[1], reverse=True)
+        # Allocate GPUs starting from the lowest index rather than the one with
+        # the most free memory so GPU 0 is preferred when available.
+        candidates.sort(key=lambda t: t[0])
         if required <= 0:
+            for idx, free in candidates:
+                if free > 0:
+                    return [idx]
             return [candidates[0][0]]
         total_free = 0
         chosen = []


### PR DESCRIPTION
## Summary
- make GPU selection prefer lowest-index GPU when VRAM requirement is 0
- accumulate free memory from lowest index for positive requirements

## Testing
- `python -m py_compile agent/agent.py`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_686ce2224478832089222c3b54a19df3