### PR TITLE
Extend agent request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ uvicorn agent.agent:app --port 8001
 
 - `AGENT_URL`: URL where the agent can be reached (used by the backend).
   Defaults to `http://localhost:8001`.
+- `AGENT_TIMEOUT`: Timeout in seconds for requests from the backend to the agent.
+  Defaults to `30`.
 - `BACKEND_URL`: URL of the backend API (used by the agent).
   Defaults to `http://localhost:8000`.
 - `PROXY_LINK_PATH`: path where the agent attempts to symlink the generated

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,7 @@ UPLOAD_DIR = "./uploads"
 LOG_DIR = "./logs"
 TEMPLATE_DIR = "./templates"
 AGENT_URL = os.environ.get("AGENT_URL", "http://localhost:8001")
+AGENT_TIMEOUT = int(os.environ.get("AGENT_TIMEOUT", 30))
 
 # Port range to allocate for running apps
 PORT_START = int(os.environ.get("PORT_START", 9000))
@@ -625,7 +626,7 @@ async def upload_app(
                     "auth_header": auth_header,
                     "vram_required": vram_required,
                 },
-                timeout=5,
+                timeout=AGENT_TIMEOUT,
             )
             resp.raise_for_status()
         save_status(
@@ -863,7 +864,7 @@ async def deploy_template(template_id: str, vram_required: int | None = Form(Non
                     "auth_header": None,
                     "vram_required": vram_required,
                 },
-                timeout=5,
+                timeout=AGENT_TIMEOUT,
             )
             resp.raise_for_status()
         save_status(
@@ -1104,7 +1105,7 @@ async def restart_app(app_id: str):
                     "auth_header": auth_header,
                     "vram_required": vram_required,
                 },
-                timeout=5,
+                timeout=AGENT_TIMEOUT,
             )
             resp.raise_for_status()
         save_status(
@@ -1213,7 +1214,7 @@ async def delete_app(app_id: str):
                 await client.post(
                     f"{AGENT_URL}/stop",
                     json={"app_id": app_id},
-                    timeout=5,
+                    timeout=AGENT_TIMEOUT,
                 )
         except Exception:
             pass
@@ -1224,7 +1225,7 @@ async def delete_app(app_id: str):
                 await client.post(
                     f"{AGENT_URL}/remove_route",
                     json={"app_id": app_id},
-                    timeout=5,
+                    timeout=AGENT_TIMEOUT,
                 )
         except Exception:
             pass
@@ -1337,7 +1338,7 @@ async def cleanup_task():
                     resp = await client.post(
                         f"{AGENT_URL}/stop",
                         json={"app_id": app_id},
-                        timeout=5,
+                        timeout=AGENT_TIMEOUT,
                     )
                     resp.raise_for_status()
             except Exception:
@@ -1346,7 +1347,7 @@ async def cleanup_task():
                         await client.post(
                             f"{AGENT_URL}/remove_route",
                             json={"app_id": app_id},
-                            timeout=5,
+                            timeout=AGENT_TIMEOUT,
                         )
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- add `AGENT_TIMEOUT` setting
- use the new constant when contacting the agent
- document `AGENT_TIMEOUT` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e03df2f3c8320a17acc9c14a2636f