### PR TITLE
Prefer app.py for Gradio apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ uvicorn backend.main:app --reload
 ### Uploading Gradio or Docker apps
 
 1. **Prepare your files**
-   - **Gradio**: upload a single Python file or a zip archive containing your Gradio app. The backend will run the first `.py` file it finds in the uploaded directory.
+   - **Gradio**: upload a single Python file or a zip archive containing your Gradio app. If an `app.py` file is present it will be used; otherwise the backend runs the first `.py` file it finds in the uploaded directory.
      If the archive contains a `requirements.txt` file it will be installed into
      a fresh Python **3.10** virtual environment which is then used to run the
      script.

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -566,7 +566,10 @@ async def build_and_run(req: RunRequest):
         proc = await async_run_detached(run_cmd, req.log_path, env=env)
     else:  # gradio
         py_files = [f for f in os.listdir(req.path) if f.endswith(".py")]
-        target = py_files[0] if py_files else None
+        if "app.py" in py_files:
+            target = "app.py"
+        else:
+            target = py_files[0] if py_files else None
         if not target:
             try:
                 async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary
- pick `app.py` when launching Gradio apps if present
- document the new preference for `app.py` in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870a4f0f7388320a89f0d12ee8ca94d