### PR TITLE
Fix multi GPU allocation

### DIFF
--- a/tests/test_gpu_usage.py
+++ b/tests/test_gpu_usage.py
@@ -72,3 +72,15 @@ def test_release_process_entry(monkeypatch):
     agent.release_process_entry('app')
     assert agent.GPU_USAGE.get(0, 0) == 0
     assert 'app' not in agent.PROCESSES
+
+
+def test_multi_gpu_allocation(monkeypatch):
+    output = "0, 40000, 1000\n1, 40000, 1000\n"
+    dummy = DummySubprocess(output)
+    monkeypatch.setattr(agent, 'subprocess', dummy)
+    reset_state()
+
+    gpus = agent.get_available_gpu(60000)
+    assert gpus == [0, 1]
+    assert agent.GPU_USAGE[0] == 39000
+    assert agent.GPU_USAGE[1] == 21000


### PR DESCRIPTION
## Summary
- extend agent's `get_available_gpu` to allocate multiple GPUs when one GPU can't satisfy vram requirement
- add test covering multi-GPU selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875b69630b48320adb41204f5d7e625