### PR TITLE
Add file download endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ uvicorn backend.main:app --reload
   - `auth_header`: header value required for access (sent as `Authorization`, optional).
 - `GET /status`: check running status of apps.
 - `GET /logs/{app_id}`: view logs for an app.
+- `GET /files/{app_id}/{filename}`: download a stored file as an attachment.
 - `POST /update_status`: (used by agent) update status in the database.
 - `POST /stop/{app_id}`: stop a running app.
 - `POST /restart/{app_id}`: restart a previously uploaded Docker app using the existing image.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1029,6 +1029,17 @@ async def get_logs(app_id: str):
         return f.read()
 
 
+@app.get("/files/{app_id}/{filename}")
+async def download_file(app_id: str, filename: str):
+    """Return a file from the uploads directory as an attachment."""
+    if not ALLOWED_FILENAME.fullmatch(filename):
+        raise HTTPException(status_code=400, detail="invalid filename")
+    path = os.path.join(UPLOAD_DIR, app_id, filename)
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="file not found")
+    return FileResponse(path, filename=filename)
+
+
 @app.post("/stop/{app_id}")
 async def stop_app_by_id(app_id: str, background_tasks: BackgroundTasks):
     """Stop a running app via the agent and mark it stopped."""

--- a/examples/video_download_app.py
+++ b/examples/video_download_app.py
@@ -1,0 +1,30 @@
+import gradio as gr
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+import os
+
+# Path to a sample video file (provide your own file in practice)
+VIDEO_PATH = os.environ.get("VIDEO_PATH", "sample.mp4")
+
+app = FastAPI()
+
+@app.get("/download")
+def download():
+    if not os.path.exists(VIDEO_PATH):
+        return {"error": "video not found"}
+    return FileResponse(VIDEO_PATH, media_type="video/mp4", filename=os.path.basename(VIDEO_PATH))
+
+
+def generate_video(text):
+    # Dummy implementation just returns existing video file
+    return VIDEO_PATH
+
+with gr.Blocks() as demo:
+    name = gr.Textbox(label="Your name")
+    video = gr.Video()
+    btn = gr.Button("Create Video")
+    btn.click(generate_video, name, video)
+    gr.HTML('<a href="/download" download class="gr-button">Download</a>')
+
+if __name__ == "__main__":
+    demo.launch(server_port=int(os.environ.get("PORT", 7860)), server_name="0.0.0.0", fastapi_app=app)


### PR DESCRIPTION
## Summary
- add `/files/{app_id}/{filename}` endpoint for downloading uploaded files
- document the new endpoint in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68760b8d439c8320b6af12f975c25521