### PR TITLE
Fix GPU allocation return and add tests

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -221,20 +221,6 @@ def get_available_gpu(required: int = 0) -> Optional[Tuple[List[int], Dict[int, 
                     GPU_USAGE[idx] = GPU_USAGE.get(idx, 0) + amt
                 return list(allocation.keys()), allocation
 
-            # attempt multi-GPU allocation
-            allocation: Dict[int, int] = {}
-            remaining = required
-            for idx, free in candidates:
-                if remaining <= 0:
-                    break
-                take = min(remaining, free)
-                allocation[idx] = take
-                remaining -= take
-
-            if remaining <= 0:
-                reserve_gpus(allocation)
-                return list(allocation.keys())
-
             # otherwise insufficient memory
             return None
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -5,6 +5,12 @@ import sys
 import types
 
 sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+# Minimal pydantic stub
+pydantic_mod = types.ModuleType("pydantic")
+class _BaseModel:
+    pass
+pydantic_mod.BaseModel = _BaseModel
+sys.modules.setdefault("pydantic", pydantic_mod)
 # Minimal FastAPI stub to avoid heavy dependencies during import
 fastapi_mod = types.ModuleType("fastapi")
 

--- a/tests/test_gpu_usage.py
+++ b/tests/test_gpu_usage.py
@@ -20,6 +20,13 @@ class DummyAsyncClient:
 httpx_stub.AsyncClient = DummyAsyncClient
 sys.modules.setdefault("httpx", httpx_stub)
 
+# Minimal pydantic stub so agent can be imported
+pydantic_stub = types.ModuleType("pydantic")
+class _BaseModel:
+    pass
+pydantic_stub.BaseModel = _BaseModel
+sys.modules.setdefault("pydantic", pydantic_stub)
+
 import agent.agent as agent
 
 # Helper to patch subprocess.check_output for nvidia-smi
@@ -43,6 +50,7 @@ def test_partial_allocation(monkeypatch):
 
     res = agent.get_available_gpu(2000)
     assert res is not None
+    assert isinstance(res, tuple)
     gpus, usage = res
     assert gpus == [0]
     assert usage == {0: 2000}
@@ -50,6 +58,7 @@ def test_partial_allocation(monkeypatch):
 
     res = agent.get_available_gpu(7000)
     assert res is not None
+    assert isinstance(res, tuple)
     gpus, usage = res
     assert gpus == [1]
     assert usage == {1: 7000}
@@ -67,6 +76,7 @@ def test_release_process_entry(monkeypatch):
 
     res = agent.get_available_gpu(4000)
     assert res is not None
+    assert isinstance(res, tuple)
     gpus, usage = res
     assert gpus == [0]
     agent.PROCESSES['app'] = {
@@ -91,6 +101,7 @@ def test_multi_gpu_allocation(monkeypatch):
 
     res = agent.get_available_gpu(60000)
     assert res is not None
+    assert isinstance(res, tuple)
     gpus, usage = res
     assert gpus == [0, 1]
     assert usage == {0: 39000, 1: 21000}


### PR DESCRIPTION
## Summary
- remove duplicate multi-GPU allocation block
- always return `(list(allocation.keys()), allocation)` on success
- stub `pydantic` module in tests
- verify return type in GPU allocation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6881ebd930d88320a29467bdc669434b